### PR TITLE
chore(deps): upgrade to autocomplete.js 0.19.0 to fix the mouseleave events

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "algoliasearch": "^3.13.1",
-    "autocomplete.js": "^0.18.0",
+    "autocomplete.js": "^0.19.0",
     "events": "^1.1.0"
   }
 }


### PR DESCRIPTION
Fix #118