### PR TITLE
feat(originalAlgoliaResponse): add originalAlgoliaResponse event data

### DIFF
--- a/docs/source/javascripts/index.js
+++ b/docs/source/javascripts/index.js
@@ -7,7 +7,6 @@ import './docsearch.js';
 responsiveNavigation();
 
 const $input = document.querySelector('#landing-demo');
-const $response = document.querySelector('#json-response');
 const placesAutocomplete = places({
   container: $input
 });
@@ -30,12 +29,22 @@ if (process.env.NODE_ENV === 'development') {
   );
 }
 
+const $response = document.querySelector('#json-response');
+const $responseText = document.querySelector('#json-response-text');
+const $responseTiming = document.querySelector('#json-response-timing');
 placesAutocomplete.on('change', function(e) {
   if (e.query === '') {
-    $response.textContent = '';
+    $responseText.textContent = '';
     $response.classList.remove('display');
   } else {
-    $response.textContent = JSON.stringify(e, null, 2);
+    const content = {
+      ...e,
+      // hide advanced API event data in demo
+      rawAnswer: undefined,
+      suggestionIndex: undefined
+    };
+    $responseText.textContent = JSON.stringify(content, null, 2);
+    $responseTiming.innerHTML = `Computed in <u>${e.rawAnswer.processingTimeMS}ms</u>`;
     $response.classList.add('display');
   }
 });

--- a/docs/source/partials/documentation.md.erb
+++ b/docs/source/partials/documentation.md.erb
@@ -258,9 +258,10 @@ placesAutocomplete.on('change', e => console.log(e.suggestion));
 
 Event data:
 
-- suggestion *Type: [suggestion](#suggestion-object)*
-- query *Type: string*,
-- suggestionIndex *Type: number*
+- *rawAnswer* <br>Type: object
+- *query* <br>Type: string
+- *suggestion* <br>Type: [suggestion](#suggestion-object)
+- *suggestionIndex* <br>Type: number
 </td>
 <td markdown="1">
 Fired when suggestion selected in the dropdown or hint was validated.
@@ -274,8 +275,9 @@ You can use this event to then populate another form, [see the example](examples
 
 Event data:
 
-- suggestions *Type: [suggestion](#suggestion-object)*
-- query *Type: string*
+- *rawAnswer* <br>Type: object
+- *query* <br>Type: string
+- *suggestions* <br>Type:  [suggestion](#suggestion-object)
 </td>
 <td markdown="1">
 Fired when dropdown receives suggestions. You will receive the array of suggestions that are displayed.
@@ -291,9 +293,10 @@ You can use this event to display the suggestions on a map, see the [map example
 
 Event data:
 
-- suggestion *Type: [suggestion](#suggestion-object)*
-- query *Type: string*
-- suggestionIndex *Type: number*
+- *rawAnswer* <br>Type: object
+- *query* <br>Type: string
+- *suggestion* <br>Type: [suggestion](#suggestion-object)
+- *suggestionIndex* <br>Type: number
 </td>
 <td markdown="1">
 Fired when arrows keys are used to navigate suggestions.

--- a/docs/source/partials/hero.html.haml
+++ b/docs/source/partials/hero.html.haml
@@ -18,6 +18,8 @@
 
   %div.relative
     %div#json-response
+      %div#json-response-text
+      %div#json-response-timing
 
   %div.examples-intro
     %div.items-holder

--- a/docs/source/stylesheets/components/_code-highlight.scss
+++ b/docs/source/stylesheets/components/_code-highlight.scss
@@ -133,14 +133,8 @@ a code {
   padding: 3px 10px;
 }
 
-
-
 #json-response {
-  unicode-bidi: embed;
-  font-family: monospace;
-  white-space: pre;
   margin: 2em auto 2em;
-  display: block;
   max-width: 940px;
   padding: 1em;
   border: 1px solid rgba(255,255,255, 0.2);
@@ -149,15 +143,24 @@ a code {
   position: relative;
   z-index: 0;
 
+  #json-response-text {
+    unicode-bidi: embed;
+    font-family: monospace;
+    white-space: pre;
+  }
+
+  #json-response-timing {
+    position: absolute;
+    bottom: .5em;
+    right: .5em;
+  }
+
   &:not(.display) {
     visibility: hidden;
   }
 
-
   &.display {
     visibility: visible;
-
-
     @extend %animated;
     @extend %fadeInDown;
   }

--- a/docs/source/stylesheets/components/_documentation.scss
+++ b/docs/source/stylesheets/components/_documentation.scss
@@ -54,6 +54,26 @@
     margin-top: 1em;
   }
 
+  .api-entry {
+    margin: 1em 0;
+    code {
+      font-size: 100%;
+      font-weight: bold;
+    }
+  }
+
+  .api tr td:first-child {
+    p, ul {
+      font-size: 90%;
+      margin: .5em 0;
+      line-height: 1.5em;
+    }
+    em {
+      text-decoration: underline;
+      font-style: normal;
+    }
+  }
+
   h2, h3, .api-entry, .css-class {
     &:before {
       content: "";


### PR DESCRIPTION
You can now access `originalAlgoliaResponse` in all event data.

Documentation updated.
Homepage example updated to include the `processingTimeMS`

![2016-05-13-110753_1043x531_scrot](https://cloud.githubusercontent.com/assets/123822/15243342/34a05e08-18fb-11e6-9106-b23e5c9fd38b.png)
