### PR TITLE
feat(autocomplete.js): create a reusable places autocomplete.js dataset

### DIFF
--- a/autocompleteDataset.js
+++ b/autocompleteDataset.js
@@ -1,0 +1,5 @@
+import createAutocompleteDataset from './src/createAutocompleteDataset.js';
+import './src/places.scss';
+
+// must use module.exports to be commonJS compatible
+module.exports = createAutocompleteDataset;

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -26,11 +26,12 @@ page '/*.txt', layout: false
 
 # Reload the browser automatically whenever files change
 configure :development do
-  config[:places_lib_url] = :places
   activate :gzip
   activate :livereload
+  config[:places_lib_url] = 'places'
+  config[:places_autocomplete_dataset_lib_url] = 'placesAutocompleteDataset'
   activate :external_pipeline,
-    name: :places,
+    name: 'places',
     command: 'npm run js:watch -- --output-path docs/.webpack/js',
     source: '.webpack'
 end
@@ -58,6 +59,7 @@ activate :protect_emails
 
 config[:places_lib_version] = ENV['VERSION']
 config[:places_cdn_url] = 'https://cdn.jsdelivr.net/places.js/0/places.min.js'
+config[:places_autocomplete_dataset_cdn_url] = 'https://cdn.jsdelivr.net/places.js/0/placesAutocompleteDataset.min.js'
 
 helpers do
   def nav_active(path)
@@ -68,6 +70,7 @@ end
 # Build-specific configuration
 configure :build do
   config[:places_lib_url] = config[:places_cdn_url]
+  config[:places_autocomplete_dataset_lib_url] = config[:places_autocomplete_dataset_cdn_url]
   # this may trigger bad behavior, if so, see
   # https://github.com/middleman/middleman-minify-html
   activate :minify_html

--- a/docs/source/javascripts/activateClipboard.js
+++ b/docs/source/javascripts/activateClipboard.js
@@ -12,10 +12,15 @@ export default function activateClipboard(codeSamples) {
       text: () => codeSample.textContent
     });
 
-    copyToClipboard.classList.add('hint--top');
-    copyToClipboard.addEventListener('mouseleave', () => copyToClipboard.removeAttribute('data-hint'));
-    clipboard.on('success', () => copyToClipboard.setAttribute('data-hint', 'Copied!'));
+    copyToClipboard.addEventListener('mouseleave', () => {
+      copyToClipboard.removeAttribute('aria-label');
+      copyToClipboard.classList.remove('hint--top');
+    });
+    clipboard.on('success', () => {
+      copyToClipboard.classList.add('hint--top');
+      copyToClipboard.setAttribute('aria-label', 'Copied!');
+    });
     // safari: https://clipboardjs.com/#browser-support
-    clipboard.on('error', () => copyToClipboard.setAttribute('data-hint', 'Hit ⌘+C to copy'));
+    clipboard.on('error', () => copyToClipboard.setAttribute('aria-label', 'Hit ⌘+C to copy'));
   });
 }

--- a/docs/source/javascripts/docsearch.js
+++ b/docs/source/javascripts/docsearch.js
@@ -3,8 +3,7 @@ import docsearch from 'docsearch.js';
 const search = docsearch({
   apiKey: '5718722ffb11e109821befd53a1d9fde',
   indexName: 'places',
-  inputSelector: '#docsearch',
-  debug: true
+  inputSelector: '#docsearch'
 });
 
 const form = document.querySelector('#docsearch-form');

--- a/docs/source/javascripts/index.js
+++ b/docs/source/javascripts/index.js
@@ -20,7 +20,12 @@ if (process.env.NODE_ENV === 'development') {
       if (typeof console.table === 'function') {
         Object.keys(eventData).forEach(dataKeyName => {
           console.log(`data: ${dataKeyName}`);
-          console.table(eventData[dataKeyName]);
+          const data = eventData[dataKeyName];
+          if (Array.isArray(data)) {
+            console.table(data);
+          } else {
+            console.log(data);
+          }
         });
       } else {
         console.log('event data:', eventData);
@@ -40,6 +45,13 @@ placesAutocomplete.on('change', function(e) {
     const content = {
       ...e,
       // hide advanced API event data in demo
+      suggestion: {
+        ...e.suggestion,
+        hit: undefined,
+        hitIndex: undefined,
+        query: undefined,
+        rawAnswer: undefined
+      },
       rawAnswer: undefined,
       suggestionIndex: undefined
     };

--- a/docs/source/partials/documentation.md.erb
+++ b/docs/source/partials/documentation.md.erb
@@ -184,13 +184,13 @@ Change the templates used in place.js.
 
 Available templates:
 
-- inputValue
-- dropdownSuggestion
+- value
+- suggestion
 
 Each template is a function that will receive a [suggestion object](#suggestion-object) and must return
 a `string`.
 
-`inputValue` must return a plain string as it's used to fill the `input.value`. `dropdownSuggestion` can
+`value` must return a plain string as it's used to fill the `input.value`. `suggestion` should
 return an HTML string to be displayed in the dropdown.
 </td>
     </tr>
@@ -425,9 +425,39 @@ Examples:
   </tbody>
 </table>
 
-### API
+### autocomplete.js
 
-The documentation of the underlying REST API can be found [here](rest.html).
+places.js is reusing [Algolia's autocomplete.js](https://github.com/algolia/autocomplete.js) library.
+
+To be able to mix and search into your own data along with showing results of places,
+we provide an [autocomplete.js dataset](https://github.com/algolia/autocomplete.js#datasets):
+
+```html
+<%= javascript_include_tag config[:places_autocomplete_dataset_cdn_url] %>
+```
+
+See the [autocomplete.js dataset example](examples.html#autocompletejs).
+
+You will need an [Algolia account](https://www.algolia.com/) to be able to search into your own data.
+
+The autocomplete.js dataset is exported as `placesAutocompleteDataset` in the window, also available with npm
+using:
+
+```js
+import placesAutocompleteDataset from 'places.js/placesAutocompleteDataset';
+```
+
+All the places.js [options](#options) are available and can be passed to
+the `placesAutocompleteDataset` function.
+
+The places.js CSS file is automatically loaded so that the rendering of suggestions is already the one
+you will expect.
+
+### REST API
+
+Behind the places.js the JavaScript library lies a complete REST API.
+
+Read the underlying [REST API documentation](rest.html).
 
 ## Styling
 
@@ -475,54 +505,54 @@ Here's a default empty CSS file you can copy paste to tune the default styling:
 .algolia-places {}
 
 /* The algolia-places input */
-.algolia-places .ap-input, .algolia-places .ap-hint {}
+.ap-input, .ap-hint {}
 
 /* The style of the svg icons when the input is on hover */
-.algolia-places .ap-input:hover ~ .ap-input-icon svg,
-.algolia-places .ap-input:focus ~ .ap-input-icon svg,
-.algolia-places .ap-input-icon:hover svg {}
+.ap-input:hover ~ .ap-input-icon svg,
+.ap-input:focus ~ .ap-input-icon svg,
+.ap-input-icon:hover svg {}
 
 /* The dropdown style */
-.algolia-places .ap-dropdown-menu {}
+.ap-dropdown-menu {}
 
 /* The suggestions style */
-.algolia-places .ap-suggestion {}
+.ap-suggestion {}
 
 /* The highlighted names style */
-.algolia-places .ap-suggestion em {}
+.ap-suggestion em {}
 
 /* The addresses style */
-.algolia-places .ap-address {}
+.ap-address {}
 
 /* The icons of each suggestions ( can be a building or a pin ) */
-.algolia-places .ap-suggestion-icon {}
+.ap-suggestion-icon {}
 
 /* The style of the svg inside the .ap-suggestion-icon */
-.algolia-places .ap-suggestion-icon svg {}
+.ap-suggestion-icon svg {}
 
 /* The icons inside the input ( can be a pin or a cross ) */
-.algolia-places .ap-input-icon {}
+.ap-input-icon {}
 
 /* The style of the svg inside the .ap-input-icon */
-.algolia-places .ap-input-icon svg {}
+.ap-input-icon svg {}
 
 /* .a-cursor is the class a suggestion go on hover */
-.algolia-places .ap-cursor {}
+.ap-cursor {}
 
 /* The style of the svg icon, when the .ap-suggestion is on hover */
-.algolia-places .ap-cursor .ap-suggestion-icon svg {}
+.ap-cursor .ap-suggestion-icon svg {}
 
 /* The styles of the Algolia Places input footer */
-.algolia-places .ap-footer {}
+.ap-footer {}
 
 /* The styles of the Algolia Places input footer links */
-.algolia-places .ap-footer a {}
+.ap-footer a {}
 
 /* The styles of the Algolia Places input footer svg icons */
-.algolia-places .ap-footer a svg {}
+.ap-footer a svg {}
 
 /* The styles of the Algolia Places input footer on hover */
-.algolia-places .ap-footer:hover {}
+.ap-footer:hover {}
 ```
 
 ### Disabling default style
@@ -533,12 +563,13 @@ Once you do so, the default `algolia-places` class name will turn into `algolia-
 
 ## Browser support
 
-Algolia Places comes with native support for all current major browsers: Chrome, Firefox, Edge, Opera and Safari.
+Algolia Places comes with native support for all latest stable versions of
+current major browsers: Chrome, Firefox, Edge, Opera and Safari. Previous versions of those
+modern browsers should also work. But since those are auto-updating browsers, we do not guarantee it.
 
-It also works natively on Internet Explorer 11 and 10.
+Algolia Places also works natively on Internet Explorer 11 and 10.
 
 To support Internet Explorer 9, you need to include a polyfill for [Element.classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList). To do so, you can use the [Polyfill.io service](https://cdn.polyfill.io/v2/docs/).
-
 
 ## Rate limits
 

--- a/docs/source/partials/examples/_autocomplete_dataset.html.erb
+++ b/docs/source/partials/examples/_autocomplete_dataset.html.erb
@@ -1,0 +1,70 @@
+<input type="search" id="autocomplete-dataset" class="form-control" placeholder="Search for products or places" />
+
+<script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"></script>
+<script src="https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.js"></script>
+<style>
+.ad-example-dropdown-menu {
+  width: 100%;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-top: none;
+  border-radius: 5px;
+  padding: .5em;
+  box-shadow: 1px 1px 32px -10px rgba(0,0,0,0.62);
+}
+.ad-example-dropdown-menu .ad-example-suggestion {
+  cursor: pointer;
+  padding: 5px 4px;
+}
+.ad-example-dropdown-menu .ad-example-suggestion.ad-example-cursor {
+  background-color: #B2D7FF;
+}
+.ad-example-dropdown-menu .ad-example-suggestion em {
+  font-weight: bold;
+  font-style: normal;
+}
+.ad-example-header {
+  font-weight: bold;
+  padding: .5em 0;
+  margin-bottom: 1em;
+  border-bottom: 1px solid #ccc;
+}
+</style>
+<%= javascript_include_tag config[:places_autocomplete_dataset_lib_url] %>
+<script>
+(function() {
+  var client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+  var index = client.initIndex('instant_search');
+
+  // create the first autocomplete.js dataset: products
+  var productsDataset = {
+    source: autocomplete.sources.hits(index, {hitsPerPage: 5, attributesToSnippet: ['name:7']}),
+    displayKey: 'name',
+    name: 'products',
+    templates: {
+      header: '<div class="ad-example-header">Products</div>',
+      suggestion: function(suggestion) {
+        return suggestion._snippetResult.name.value;
+      }
+    }
+  };
+
+  // create the second dataset: places
+  // we automatically inject the default CSS
+  // all the places.js options are available
+  var placesDataset = placesAutocompleteDataset({
+    algoliasearch: algoliasearch,
+    templates: {
+      header: '<div class="ad-example-header">Places</div>'
+    }
+  });
+
+  // init
+  var datasets = [productsDataset, placesDataset];
+  autocomplete(
+    document.querySelector('#autocomplete-dataset'),
+    {hint: false, cssClasses: {prefix: 'ad-example'}},
+    datasets
+  );
+})();
+</script>

--- a/docs/source/partials/examples/_city_search.html.erb
+++ b/docs/source/partials/examples/_city_search.html.erb
@@ -7,7 +7,7 @@
     container: document.querySelector('#city'),
     type: 'city',
     templates: {
-      inputValue: function(suggestion) {
+      value: function(suggestion) {
         return suggestion.name;
       }
     }

--- a/docs/source/partials/examples/_complete_form.html.erb
+++ b/docs/source/partials/examples/_complete_form.html.erb
@@ -24,7 +24,7 @@
     container: document.querySelector('#form-address'),
     type: 'address',
     templates: {
-      inputValue: function(suggestion) {
+      value: function(suggestion) {
         return suggestion.name;
       }
     }

--- a/docs/source/partials/examples/_country_search.html.erb
+++ b/docs/source/partials/examples/_country_search.html.erb
@@ -11,7 +11,7 @@
     container: document.querySelector('#country'),
     type: 'country',
     templates: {
-      dropdownSuggestion: function(suggestion) {
+      suggestion: function(suggestion) {
         return '<i class="flag ' + suggestion.countryCode + '"></i> ' +
           suggestion.name;
       }

--- a/docs/source/partials/examples/_index.md.erb
+++ b/docs/source/partials/examples/_index.md.erb
@@ -121,7 +121,21 @@ To disable all styling, use the `style` option:
 ```html
 <%= partial '/partials/examples/full_styling' %>
 ```
-
 Once you do so, the default `algolia-places` class name will turn into `algolia-places-nostyle`.
 
 See our [documentation about styling](./documentation.html#styling) for more details.
+
+## autocomplete.js
+
+Using [Algolia's autocomplete.js](https://github.com/algolia/autocomplete.js) library, you can search
+in your own data along with showing Algolia Places results.
+
+You need an Algolia account to do so and the Algolia Places dataset:
+
+<%= partial '/partials/examples/autocomplete_dataset' %>
+
+```html
+<%= partial '/partials/examples/autocomplete_dataset' %>
+```
+
+See the documentation about the [placesAutocompleteDataset function](documentation.html##autocompletejs).

--- a/docs/source/partials/examples/_simple_input.html.erb
+++ b/docs/source/partials/examples/_simple_input.html.erb
@@ -1,7 +1,6 @@
 <input type="search" id="address" class="form-control" placeholder="Where are we going?" />
 
-<p>Change event data:</p>
-<pre id="address-value"></pre>
+<p>Selected: <strong id="address-value">none</strong></p>
 
 <%= javascript_include_tag config[:places_lib_url] %>
 <script>
@@ -11,11 +10,9 @@
   });
 
   placesAutocomplete.on('change', function(e) {
-    console.log(e);
-
     document
       .querySelector('#address-value')
-      .textContent = JSON.stringify(e, null, 2);
+      .textContent = e.suggestion ? e.suggestion.value : 'none';
   });
 })();
 </script>

--- a/docs/source/partials/examples/_templates.html.erb
+++ b/docs/source/partials/examples/_templates.html.erb
@@ -6,10 +6,10 @@
   var placesAutocomplete = places({
     container: document.querySelector('#address-templates'),
     templates: {
-      inputValue: function(suggestion) {
+      value: function(suggestion) {
         return 'Maybe ' + suggestion.name + ' in ' + suggestion.country + '?';
       },
-      dropdownSuggestion: function(suggestion) {
+      suggestion: function(suggestion) {
         return '<u>Click here to select ' + suggestion.name + ' from ' + suggestion.country + '</u>';
       }
     }

--- a/docs/source/partials/rest.md.erb
+++ b/docs/source/partials/rest.md.erb
@@ -120,107 +120,76 @@ given the area density.
   </tbody>
 </table>
 
-### Answer
+### JSON answer
 
 The API answers is using the JSON format and looks like:
 
-```json
+```js
 {
-  "hits" : [
-    {
-       "objectID" : "145746683_7444",
-       "locale_names" : {
-          "ar" : ["باريس"],
-          "ru" : ["Париж"],
-          "fr" : ["Paris", "Lutèce"],
-          "it" : ["Parigi"],
-          "default" : ["Paris"],
-          "pl" : ["Paryż"],
-          "hu" : ["Párizs"],
-          "ja" : ["パリ"],
-          "nl" : ["Parijs"],
-          "es" : ["París"],
-          "zh" : ["巴黎"]
-       },
-       "city" : {
-          "ja" : ["パリ"],
-          "nl" : ["Parijs"],
-          "es" : ["París"],
-          "zh" : ["巴黎"],
-          "ru" : ["Париж"],
-          "ar" : ["باريس"],
-          "it" : ["Parigi"],
-          "pl" : ["Paryż"],
-          "default" : ["Paris"],
-          "hu" : ["Párizs"]
-       },
-       "county" : {
-          "hu" : ["Párizs"],
-          "pl" : ["Paryż"],
-          "default" : ["Paris"],
-          "it" : ["Parigi"],
-          "ar" : ["باريس"],
-          "ru" : ["Париж"],
-          "zh" : ["巴黎"],
-          "es" : ["París"],
-          "ja" : ["パリ"],
-          "nl" : ["Parijs"]
-       },
-       "administrative" : ["Île-de-France"],
-       "country" : {
-          "es" : "Francia",
-          "nl" : "Frankrijk",
-          "ja" : "フランス",
-          "ro" : "Franța",
-          "zh" : "法国",
-          "it" : "Francia",
-          "ru" : "Франция",
-          "ar" : "فرنسا",
-          "de" : "Frankreich",
-          "pt" : "França",
-          "hu" : "Franciaország",
-          "default" : "France",
-          "pl" : "Francja"
-       },
-       "country_code" : "fr",
-       "postcode" : ["75000"],
-       "population" : 2243833,
-       "_geoloc" : {
-          "lat" : 48.8564,
-          "lng" : 2.3521
-       },
-       "_highlightResult" : {
-          "country" : {
-             // [...]
-          },
-          "city" : {
-             // [...]
-          },
-          "county" : {
-             // [...]
-          },
-          "postcode" : [
-             // [...]
-          ],
-          "administrative" : [
-             // [...]
-          ],
-          "locale_names" : {
-             "default" : [
-                {
-                   "value" : "<em>Paris</em>",
-                   "fullyHighlighted" : true,
-                   "matchedWords" : ["paris"],
-                   "matchLevel" : "full"
-                }
-             ]
-             // [...]
-          }
-       }
+  "hits": [{
+    "objectID": "145746683_7444",
+    "locale_names": {
+      "ar": ["باريس"],
+      "ru": ["Париж"],
+      "fr": ["Paris", "Lutèce"],
+      "it": ["Parigi"],
+      "default": ["Paris"],
+      "pl": ["Paryż"],
+      "hu": ["Párizs"],
+      "ja": ["パリ"],
+      "nl": ["Parijs"],
+      "es": ["París"],
+      "zh": ["巴黎"]
+    },
+    "city": {
+      "default": ["Paris"],
+      // ... other languages
+    },
+    "county": {
+      "default": ["Paris"],
+      // ... other languages
+    },
+    "administrative": ["Île-de-France"],
+    "country": {
+      "default": "France",
+      // ... other languages
+    },
+    "country_code": "fr",
+    "postcode": ["75000"],
+    "population": 2243833,
+    "_geoloc": {
+      "lat": 48.8564,
+      "lng": 2.3521
+    },
+    "_highlightResult": {
+      "country": {
+        // [...]
+      },
+      "city": {
+        // [...]
+      },
+      "county": {
+        // [...]
+      },
+      "postcode": [
+        // [...]
+      ],
+      "administrative": [
+        // [...]
+      ],
+      "locale_names": {
+        "default": [{
+            "value": "<em>Paris</em>",
+            "fullyHighlighted": true,
+            "matchedWords": ["paris"],
+            "matchLevel": "full"
+          }]
+          // [...]
+      }
     }
-  ],
-  "nbHits" : 1,
-  "query" : "Paris"
+  }],
+  "nbHits": 1,
+  "query": "Paris"
 }
 ```
 

--- a/docs/source/stylesheets/site.css.scss
+++ b/docs/source/stylesheets/site.css.scss
@@ -27,5 +27,5 @@
 @import 'components/docsearch/dropdown';
 @import 'components/docsearch/searchbox';
 
-@include dropdown($dropdown-config...);
 @include searchbox($searchbox-config...);
+@include dropdown($dropdown-config...);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
-    "algoliasearch": "^3.14.0",
+    "algoliasearch": "^3.14.6",
     "autocomplete.js": "^0.19.0",
     "events": "^1.1.0"
   }

--- a/src/createAutocompleteDataset.js
+++ b/src/createAutocompleteDataset.js
@@ -1,0 +1,19 @@
+import createAutocompleteSource from './createAutocompleteSource.js';
+import defaultTemplates from './defaultTemplates.js';
+
+export default function createAutocompleteDataset(options) {
+  const templates = {
+    ...defaultTemplates,
+    ...options.templates
+  };
+
+  return {
+    source: createAutocompleteSource({
+      ...options,
+      formatInputValue: templates.value
+    }),
+    templates,
+    displayKey: 'value',
+    name: 'places'
+  };
+}

--- a/src/createAutocompleteSource.js
+++ b/src/createAutocompleteSource.js
@@ -1,0 +1,68 @@
+import formatHit from './formatHit.js';
+import version from './version.js';
+
+export default function createAutocompleteSource({
+  algoliasearch,
+  apiKey,
+  appId,
+  aroundLatLng,
+  aroundRadius,
+  aroundLatLngViaIP,
+  countries,
+  formatInputValue,
+  language = navigator.language.split('-')[0],
+  onHits = () => {},
+  type
+}) {
+  const placesClient = algoliasearch.initPlaces(
+    apiKey,
+    appId
+  );
+  placesClient.as.setExtraHeader('targetIndexingIndexes', true);
+  placesClient.as.addAlgoliaAgent(`Algolia Places ${version}`);
+
+  let defaultQueryParams = {
+    countries,
+    hitsPerPage: 5,
+    language,
+    type
+  };
+
+  if (aroundLatLng) {
+    defaultQueryParams.aroundLatLng = aroundLatLng;
+  } else if (typeof aroundLatLngViaIP !== 'undefined') {
+    defaultQueryParams.aroundLatLngViaIP = aroundLatLngViaIP;
+  }
+
+  if (aroundRadius) {
+    defaultQueryParams.aroundRadius = aroundRadius;
+  }
+
+  return (query, cb) => placesClient
+      .search({
+        ...defaultQueryParams,
+        query
+      })
+      .then(
+        content => {
+          const hits = content.hits.map((hit, hitIndex) => {
+            return formatHit({
+              formatInputValue,
+              hit,
+              hitIndex,
+              query,
+              rawAnswer: content
+            });
+          });
+
+          onHits({
+            hits,
+            query,
+            rawAnswer: content
+          });
+
+          return hits;
+        }
+      )
+      .then(cb);
+}

--- a/src/defaultTemplates.js
+++ b/src/defaultTemplates.js
@@ -1,5 +1,5 @@
-import inputValue from './formatInputValue.js';
-import dropdownSuggestion from './formatDropdownValue.js';
+import value from './formatInputValue.js';
+import suggestion from './formatDropdownValue.js';
 import algoliaLogo from './icons/algolia.svg';
 import osmLogo from './icons/osm.svg';
 
@@ -8,6 +8,6 @@ export default {
   Built by <a href="https://www.algolia.com/?utm_source=places&utm_medium=link&utm_term=footer&utm_campaign=${location.hostname}" title="Search by Algolia" class="ap-footer-algolia">${algoliaLogo.trim()}</a>
   using <a href="https://community.algolia.com/places/documentation.html#license" class="ap-footer-osm" title="Algolia Places data © OpenStreetMap contributors">${osmLogo.trim()} <span>data</span></a>
   </div>`,
-  inputValue,
-  dropdownSuggestion
+  value,
+  suggestion
 };

--- a/src/formatDropdownValue.js
+++ b/src/formatDropdownValue.js
@@ -8,13 +8,20 @@ const icons = {
   country: countryIcon
 };
 
-export default function formatDropdownValue({
-  administrative,
-  city,
-  country,
-  type,
-  name
-}) {
+export default function formatDropdownValue(options) {
+  let {
+    administrative,
+    city,
+    country,
+    type,
+    hit
+  } = options;
+
+  const name = hit._highlightResult.locale_names[0].value;
+  city = city ? hit._highlightResult.city[0].value : undefined;
+  administrative = administrative ? hit._highlightResult.administrative[0].value : undefined;
+  country = country ? hit._highlightResult.country.value : undefined;
+
   const out = `<span class="ap-suggestion-icon">${icons[type].trim()}</span>
 <span class="ap-name">${name}</span>
 <span class="ap-address">

--- a/src/formatHit.js
+++ b/src/formatHit.js
@@ -2,25 +2,18 @@ import findCountryCode from './findCountryCode.js';
 import findType from './findType.js';
 
 export default function formatHit({
+  formatInputValue,
   hit,
   hitIndex,
   query,
-  templates
+  rawAnswer
 }) {
   try {
     const name = hit.locale_names[0];
-    const highlightedName = hit._highlightResult.locale_names[0].value;
-
     const country = hit.country;
-    const highlightedCountry = hit.country ? hit._highlightResult.country.value : undefined;
-
     const administrative = hit.administrative && hit.administrative[0] !== name ?
       hit.administrative[0] : undefined;
-    const highlightedAdministrative = administrative ?
-      hit._highlightResult.administrative[0].value : undefined;
-
     const city = hit.city && hit.city[0] !== name ? hit.city[0] : undefined;
-    const highlightedCity = city ? hit._highlightResult.city[0].value : undefined;
 
     const suggestion = {
       name,
@@ -37,29 +30,22 @@ export default function formatHit({
     };
 
     // this is the value to put inside the <input value=
-    const value = templates.inputValue(suggestion);
-    const dropdownValue = templates.dropdownSuggestion({
-      ...suggestion,
-      name: highlightedName,
-      administrative: highlightedAdministrative,
-      city: highlightedCity,
-      country: highlightedCountry
-    });
+    const value = formatInputValue(suggestion);
 
     return {
       ...suggestion,
-      value,
-      _query: query,
-      _dropdownValue: dropdownValue,
-      _index: hitIndex
+      hit,
+      hitIndex,
+      query,
+      rawAnswer,
+      value
     };
   } catch (e) {
     /* eslint no-console: 0 */
     console.error('Could not parse object', hit);
     console.error(e);
     return {
-      inputValue: 'Could not parse object',
-      _dropdownHTMLFormatted: 'Could not parse object'
+      value: 'Could not parse object'
     };
   }
 }

--- a/src/places.scss
+++ b/src/places.scss
@@ -11,104 +11,104 @@
 // see http://pxtoem.com/ to change/add values
 .algolia-places {
   width: 100%;
+}
 
-  .ap-input, .ap-hint {
-    width: 100%;
-    padding-right: 35px;
+.ap-input, .ap-hint {
+  width: 100%;
+  padding-right: 35px;
+}
+
+.ap-input:hover ~ .ap-input-icon svg,
+.ap-input:focus ~ .ap-input-icon svg,
+.ap-input-icon:hover svg {
+  fill: #aaaaaa;
+}
+
+// Dropdown
+.ap-dropdown-menu {
+  width: 100%;
+  background: #ffffff;
+  box-shadow: 0 1px 10px rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+  margin-top: 3px;
+  overflow: hidden; // avoid non rounded borders to overlap
+}
+
+.ap-suggestion {
+  cursor: pointer;
+  height: 46px;
+  line-height: 46px;
+  padding-left: 18px;
+  overflow: hidden;
+
+  em {
+    font-weight: bold;
+    font-style: normal;
   }
+}
 
-  .ap-input:hover ~ .ap-input-icon svg,
-  .ap-input:focus ~ .ap-input-icon svg,
-  .ap-input-icon:hover svg {
+.ap-address {
+  font-size: smaller;
+  margin-left: 12px; // 12px when font is 14px
+  color: #aaaaaa;
+}
+
+.ap-suggestion-icon {
+  margin-right: 10px;
+  width: 14px;
+  height: 20px;
+  vertical-align: middle; // handles right alignment with text
+
+  svg {
+    transform: scale(0.90) translateY(2px);
+    fill: #cfcfcf;
+  }
+}
+
+.ap-input-icon {
+  border: 0;
+  background: transparent;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 16px;
+  outline: none;
+
+  svg {
+    fill: #cfcfcf;
+    // keep the icons centered
+    position: absolute;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
+  }
+}
+
+.ap-cursor {
+  background: #efefef;
+
+  .ap-suggestion-icon svg {
+    transform: scale(1);
     fill: #aaaaaa;
   }
+}
 
-  // Dropdown
-  .ap-dropdown-menu {
-    width: 100%;
-    background: #ffffff;
-    box-shadow: 0 1px 10px rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-    border-radius: 3px;
-    margin-top: 3px;
-    overflow: hidden; // avoid non rounded borders to overlap
-  }
+.ap-footer {
+  opacity: .8;
+  text-align: right;
+  padding: .5em 1em .5em 0;
+  font-size: 12px;
+  line-height: 12px;
 
-  .ap-suggestion {
-    cursor: pointer;
-    height: 46px;
-    line-height: 46px;
-    padding-left: 18px;
-    overflow: hidden;
-
-    em {
-      font-weight: bold;
-      font-style: normal;
-    }
-  }
-
-  .ap-address {
-    font-size: smaller;
-    margin-left: 12px; // 12px when font is 14px
-    color: #aaaaaa;
-  }
-
-  .ap-suggestion-icon {
-    margin-right: 10px;
-    width: 14px;
-    height: 20px;
-    vertical-align: middle; // handles right alignment with text
-
+  a {
+    color: inherit;
+    text-decoration: none;
     svg {
-      transform: scale(0.90) translateY(2px);
-      fill: #cfcfcf;
+      vertical-align: middle;
     }
   }
 
-  .ap-input-icon {
-    border: 0;
-    background: transparent;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 16px;
-    outline: none;
-
-    svg {
-      fill: #cfcfcf;
-      // keep the icons centered
-      position: absolute;
-      top: 50%;
-      right: 0;
-      transform: translateY(-50%);
-    }
-  }
-
-  .ap-cursor {
-    background: #efefef;
-
-    .ap-suggestion-icon svg {
-      transform: scale(1);
-      fill: #aaaaaa;
-    }
-  }
-
-  .ap-footer {
-    opacity: .8;
-    text-align: right;
-    padding: .5em 1em .5em 0;
-    font-size: 12px;
-    line-height: 12px;
-
-    a {
-      color: inherit;
-      text-decoration: none;
-      svg {
-        vertical-align: middle;
-      }
-    }
-
-    &:hover {
-      opacity: 1;
-    }
+  &:hover {
+    opacity: 1;
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -2,12 +2,15 @@ import webpack from 'webpack';
 import {join} from 'path';
 
 export default {
-  entry: './index.js',
+  entry: {
+    places: './index.js',
+    placesAutocompleteDataset: './autocompleteDataset.js'
+  },
   devtool: 'source-map',
   output: {
     path: './dist/cdn',
-    filename: 'places.js',
-    library: 'places',
+    filename: '[name].js',
+    library: '[name]',
     libraryTarget: 'umd'
   },
   module: {


### PR DESCRIPTION
This PR adds a new autocomplete.js dataset for places. Making it very easy to mix any autocomplete.js results with places.

cc @seafoox :)

+ documentation
+ small fixes
+ no need for CSS nesting, also solves styling the dataset
+ stopped using custom code to not send api keys using JS client

BREAKING CHANGES:
- templates.inputValue => templates.value
- templates.dropdownSuggestion => templates.suggestion

Preview:

![2016-05-30-215130_839x598_scrot](https://cloud.githubusercontent.com/assets/123822/15657906/f43b1f6a-26b5-11e6-8ab5-d41e8244f7c5.png)
