### PR TITLE
Fix doc and add clear event

### DIFF
--- a/docs/source/partials/documentation.md.erb
+++ b/docs/source/partials/documentation.md.erb
@@ -298,6 +298,21 @@ Fired when arrows keys are used to navigate suggestions.
 You can use this event to highlight markers on a map, see the [map example](examples.html#displaying-a-map).
 </td>
     </tr>
+    <tr>
+<td markdown="1">
+<div class="api-entry" id="api-events-clear"><code>clear</code></div>
+
+Event data: `undefined`
+
+</td>
+<td markdown="1">
+Fired when the input is cleared. This event doesn't return anything, as the value of the query is then `''`
+and no suggestion is displayed nor selected.
+
+You can use this event when used with a map to reset the pins and the default center. See this behaviour
+live on the [map example](examples.html#displaying-a-map).
+</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/source/partials/documentation.md.erb
+++ b/docs/source/partials/documentation.md.erb
@@ -187,7 +187,7 @@ Available templates:
 - value
 - suggestion
 
-Each template is a function that will receive a [suggestion object](#suggestion-object) and must return
+Each template is a function that will receive a [suggestion object](#suggestions) and must return
 a `string`.
 
 `value` must return a plain string as it's used to fill the `input.value`. `suggestion` should
@@ -252,10 +252,10 @@ placesAutocomplete.on('change', e => console.log(e.suggestion));
 
 Event data:
 
-- *rawAnswer* <br>Type: object
-- *query* <br>Type: string
-- *suggestion* <br>Type: [suggestion](#suggestion-object)
-- *suggestionIndex* <br>Type: number
+- *query* <br>Type: **string**
+- *rawAnswer* <br>Type: **object**
+- *suggestion* <br>Type: **[suggestion](#suggestions)**
+- *suggestionIndex* <br>Type: **number**
 </td>
 <td markdown="1">
 Fired when suggestion selected in the dropdown or hint was validated.
@@ -269,9 +269,9 @@ You can use this event to then populate another form, [see the example](examples
 
 Event data:
 
-- *rawAnswer* <br>Type: object
-- *query* <br>Type: string
-- *suggestions* <br>Type:  [suggestion](#suggestion-object)
+- *rawAnswer* <br>Type: **object**
+- *query* <br>Type: **string**
+- *suggestions* <br>Type:  **Array<[suggestion](#suggestions)>**
 </td>
 <td markdown="1">
 Fired when dropdown receives suggestions. You will receive the array of suggestions that are displayed.
@@ -287,10 +287,10 @@ You can use this event to display the suggestions on a map, see the [map example
 
 Event data:
 
-- *rawAnswer* <br>Type: object
-- *query* <br>Type: string
-- *suggestion* <br>Type: [suggestion](#suggestion-object)
-- *suggestionIndex* <br>Type: number
+- *rawAnswer* <br>Type: **object**
+- *query* <br>Type: **string**
+- *suggestion* <br>Type: **[suggestion](#suggestions)**
+- *suggestionIndex* <br>Type: **number**
 </td>
 <td markdown="1">
 Fired when arrows keys are used to navigate suggestions.
@@ -315,7 +315,7 @@ All of the events will send suggestion objects with those properties:
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-type"><code>type</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Type of the current suggestion, possible values: `country`, `city`, `address`.
@@ -325,7 +325,7 @@ Type of the current suggestion, possible values: `country`, `city`, `address`.
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-name"><code>name</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Display name of the place found.
@@ -340,7 +340,7 @@ Examples:
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-city"><code>city</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 City name.
@@ -350,7 +350,7 @@ City name.
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-country"><code>country</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Country name.
@@ -360,7 +360,7 @@ Country name.
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-countryCode"><code>countryCode</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Two letters country code ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements)).
@@ -370,7 +370,7 @@ Two letters country code ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_3166-1#O
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-administrative"><code>administrative</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Administrative region depending on the country.
@@ -386,7 +386,7 @@ Examples:
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-latlng"><code>latlng</code></div>
 
-Type: Object
+Type: **Object**
 </td>
 <td markdown="1">
 Latitude and longitude of the place found. Shape: `{lat: 48.797885, lng: 2.337034}`.
@@ -396,7 +396,7 @@ Latitude and longitude of the place found. Shape: `{lat: 48.797885, lng: 2.33703
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-postcode"><code>postcode</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Postcode (or ZIP Code) of the place found.
@@ -411,7 +411,7 @@ Examples:
 <td markdown="1">
 <div class="api-entry" id="api-suggestion-value"><code>value</code></div>
 
-Type: string
+Type: **string**
 </td>
 <td markdown="1">
 Full display name of the place found. It's the value displayed in the input.

--- a/docs/source/partials/examples/_complete_form.html.erb
+++ b/docs/source/partials/examples/_complete_form.html.erb
@@ -30,11 +30,9 @@
     }
   });
   placesAutocomplete.on('change', function resultSelected(e) {
-    if (e.suggestion) {
-      document.querySelector('#form-address2').value = e.suggestion.administrative || '';
-      document.querySelector('#form-city').value = e.suggestion.city || '';
-      document.querySelector('#form-zip').value = e.suggestion.postcode || '';
-    }
+    document.querySelector('#form-address2').value = e.suggestion.administrative || '';
+    document.querySelector('#form-city').value = e.suggestion.city || '';
+    document.querySelector('#form-zip').value = e.suggestion.postcode || '';
   });
 })();
 </script>

--- a/docs/source/partials/examples/_index.md.erb
+++ b/docs/source/partials/examples/_index.md.erb
@@ -89,7 +89,7 @@ Then use this:
 
 You can customize both the input value and dropdown suggestion templates.
 
-Templates are functions called with a [suggestion object](./documentation.html#suggestion-object).
+Templates are functions called with a [suggestion object](./documentation.html#suggestions).
 
 <%= partial '/partials/examples/templates' %>
 

--- a/docs/source/partials/examples/_map.html.erb
+++ b/docs/source/partials/examples/_map.html.erb
@@ -33,6 +33,7 @@
   placesAutocomplete.on('suggestions', handleOnSuggestions);
   placesAutocomplete.on('cursorchanged', handleOnCursorchanged);
   placesAutocomplete.on('change', handleOnChange);
+  placesAutocomplete.on('clear', handleOnClear);
 
   function handleOnSuggestions(e) {
     markers.forEach(removeMarker);
@@ -58,10 +59,11 @@
           removeMarker(marker);
         }
       });
-
-    if (e.query === '') {
-      map.setView(new L.LatLng(0, 0), 1);
-    }
+  }
+  
+  function handleOnClear() {
+    map.setView(new L.LatLng(0, 0), 1);
+    markers.forEach(removeMarker);
   }
 
   function handleOnCursorchanged(e) {

--- a/docs/source/partials/examples/_map_paris.html.erb
+++ b/docs/source/partials/examples/_map_paris.html.erb
@@ -68,10 +68,10 @@
           removeMarker(marker);
         }
       });
+  }
 
-    if (e.query === '') {
-      map.setView(new L.LatLng(latlng.lat, latlng.lng), 12);
-    }
+  function handleOnClear() {
+    map.setView(new L.LatLng(latlng.lat, latlng.lng), 12);
   }
 
   function handleOnCursorchanged(e) {

--- a/docs/source/partials/examples/_simple_input.html.erb
+++ b/docs/source/partials/examples/_simple_input.html.erb
@@ -9,10 +9,14 @@
     container: document.querySelector('#address')
   });
 
+  var $address = document.querySelector('#address-value')
   placesAutocomplete.on('change', function(e) {
-    document
-      .querySelector('#address-value')
-      .textContent = e.suggestion ? e.suggestion.value : 'none';
+    $address.textContent = e.suggestion.value 
   });
+
+  placesAutocomplete.on('clear', function() {
+    $address.textContent = 'none';
+  });
+
 })();
 </script>

--- a/src/places.js
+++ b/src/places.js
@@ -88,6 +88,7 @@ export default function places(options) {
     autocompleteInstance.focus();
     clear.style.display = 'none';
     pin.style.display = '';
+    placesInstance.emit('clear');
   });
 
   let previousQuery = '';
@@ -97,7 +98,7 @@ export default function places(options) {
       pin.style.display = '';
       clear.style.display = 'none';
       if (previousQuery !== query) {
-        placesInstance.emit('change', {query});
+        placesInstance.emit('clear');
       }
     } else {
       clear.style.display = '';


### PR DESCRIPTION
This PR provides some improvements to the documentation:
 - all types now are in bold
 - suggestions is now of type Array<Suggestion> to make the array more explicit
 - fix the link to the suggestion object reference

This PR also adds a new event `clear` that is triggered when the input field is cleared either when emptying manually or when it is the clear button is hit.