### PR TITLE
Fix: default style should be harmonious

### DIFF
--- a/src/places.scss
+++ b/src/places.scss
@@ -16,6 +16,13 @@
 .ap-input, .ap-hint {
   width: 100%;
   padding-right: 35px;
+  padding-left: 16px;
+  line-height: 40px;
+  height: 40px;
+  border: 1px solid #CCC;
+  border-radius: 3px;
+  outline: none;
+  font: inherit;
 }
 
 .ap-input:hover ~ .ap-input-icon svg,


### PR DESCRIPTION
By default the style seems broken which can be frustrating for new users
who want to quick test the library. I wouldn't have made changes if we
didn't already provided styles for some elements.

Fixes #181 
