### PR TITLE
fix(website): Change docsearch input color on active

### DIFF
--- a/docs/source/stylesheets/components/docsearch/_docsearch.scss
+++ b/docs/source/stylesheets/components/docsearch/_docsearch.scss
@@ -5,7 +5,7 @@ $searchbox-config: (
 	border-width: 2px,
 	border-radius: 18px,
 	input-border-color: rgba(#fff,.5),
-	input-focus-border-color: #1D95C6,
+	input-focus-border-color: rgba(#fff,.8),
 	input-background: #000,
 	font-size: 12px,
 	placeholder-color: #777,


### PR DESCRIPTION
Just changing the color of the input when focused. 

From : 
![](http://puu.sh/pl9Uq/5026d5a1b5.png)

To : 
![](http://puu.sh/pl9VT/ea63467c86.png)