### PR TITLE
feat(clientOptions): ability to set REST API client options

### DIFF
--- a/docs/source/partials/documentation.md.erb
+++ b/docs/source/partials/documentation.md.erb
@@ -226,6 +226,18 @@ Type: **string**
 If using the authenticated API, the API key to use.
 </td>
     </tr>
+    <tr>
+<td markdown="1">
+<div class="api-entry" id="api-options-clientOptions"><code>clientOptions</code></div>
+
+Type: **object**
+</td>
+<td markdown="1">
+Algolia [JavaScript API client options](https://github.com/algolia/algoliasearch-client-js#client-options).
+
+This is an advanced option.
+</td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/createAutocompleteSource.js
+++ b/src/createAutocompleteSource.js
@@ -3,6 +3,7 @@ import version from './version.js';
 
 export default function createAutocompleteSource({
   algoliasearch,
+  clientOptions,
   apiKey,
   appId,
   aroundLatLng,
@@ -16,7 +17,8 @@ export default function createAutocompleteSource({
 }) {
   const placesClient = algoliasearch.initPlaces(
     apiKey,
-    appId
+    appId,
+    clientOptions
   );
   placesClient.as.addAlgoliaAgent(`Algolia Places ${version}`);
 


### PR DESCRIPTION
This is required to override the `hosts` array for dev/test purpose for instance.

Happy to have your POV @vvo 