### PR TITLE
feat(autocompleteOptions): expose the autocompleteOptions

### DIFF
--- a/docs/source/bootstrap.html.erb
+++ b/docs/source/bootstrap.html.erb
@@ -8,6 +8,9 @@ layout: bootstrap
 
 <script>
 places({
-  container: document.querySelector('#test')
+  container: document.querySelector('#test'),
+  autocompleteOptions: {
+    debug: true
+  }
 });
 </script>

--- a/docs/source/partials/documentation.md.erb
+++ b/docs/source/partials/documentation.md.erb
@@ -237,6 +237,17 @@ Algolia [JavaScript API client options](https://github.com/algolia/algoliasearch
 
 This is an advanced option.
 </td>
+  </tr>
+  <tr>
+<td markdown="1">
+<div class="api-entry" id="api-options-autocompleteOptions"><code>autocompleteOptions</code></div>
+
+Type: **object**
+</td>
+<td markdown="1">
+[autocomplete.js options](https://github.com/algolia/autocomplete.js#options) to configure the underlying
+autocomplete.js instance.
+</td>
     </tr>
   </tbody>
 </table>

--- a/src/places.js
+++ b/src/places.js
@@ -15,24 +15,22 @@ import pinIcon from './icons/address.svg';
 export default function places(options) {
   const {
     container,
-    style
+    style,
+    autocompleteOptions: userAutocompleteOptions = {}
   } = options;
 
   const placesInstance = new EventEmitter();
 
-  // https://github.com/algolia/autocomplete.js#options
   const autocompleteOptions = {
     autoselect: true,
     hint: false,
     cssClasses: {
       root: 'algolia-places' + (style === false ? '-nostyle' : ''),
       prefix: 'ap' + (style === false ? '-nostyle' : '')
-    }
+    },
+    debug: process.env.NODE_ENV === 'development' ? true : false,
+    ...userAutocompleteOptions
   };
-
-  if (process.env.NODE_ENV === 'development') {
-    autocompleteOptions.debug = true;
-  }
 
   const autocompleteDataset = createAutocompleteDataset({
     ...options,


### PR DESCRIPTION
This could be useful to set the debug flag to `true` without relying on
process.env.NODE_ENV.