### PR TITLE
docs(support): add support menu entry

### DIFF
--- a/docs/config.rb
+++ b/docs/config.rb
@@ -44,7 +44,7 @@ set :markdown, input: 'GFM'
 
 activate :syntax, line_numbers: true, css_class: 'codehilite'
 
-[:index, :documentation, :rest, :examples, :common, 'documentation-layout'].each do |name|
+[:index, :documentation, :rest, :examples, :common, :support, 'documentation-layout'].each do |name|
   activate :external_pipeline,
     name: name,
     command: "BUNDLE=#{name} npm run docs:js:#{build? ? :build : :watch}",

--- a/docs/source/javascripts/support.js
+++ b/docs/source/javascripts/support.js
@@ -1,0 +1,20 @@
+const defaultIp = 'Find it on https://api.ipify.org';
+const defaultCoords = 'Find it on https://jsfiddle.net/qmjet97b/';
+const link = document.querySelector('#support-google-form');
+const getFormURL = (ip, coords) => `https://docs.google.com/forms/d/13r_7B72v6u6326atqzKZpv0fs_3OUOJFR-6QDipHl3Y/viewform?entry.1560244398&entry.1894094686&entry.1809496416&entry.2029760924&entry.1442423869&entry.1714224469&entry.1070945708=${encodeURIComponent(ip)}&entry.2019626860=${encodeURIComponent(coords)}`;
+link.setAttribute('href', getFormURL(defaultIp, defaultCoords));
+link.addEventListener('click', clickEvent => {
+  clickEvent.preventDefault();
+  try {
+    navigator.geolocation.getCurrentPosition(
+      ({coords}) => // success
+        window.location.href = getFormURL(
+          window.userip ? `${window.userip} (detected)` : defaultIp,
+          `${coords.latitude},${coords.longitude}  (detected)`
+        ),
+      () => window.location.href = clickEvent.target.href // error
+    );
+  } catch (geoNotAvailable) {
+    window.location.href = clickEvent.target.href;
+  }
+});

--- a/docs/source/partials/navigation.html.haml
+++ b/docs/source/partials/navigation.html.haml
@@ -27,6 +27,8 @@
           %a{href: "documentation.html", title: "Documentation", :data => {:path => "documentation.html"}} Documentation
         %li.ac-nav-menu-list-item{nav_active("examples.html")}
           %a{href: "examples.html", title: "Examples", :data => {:path => "examples.html"}} Examples
+        %li.ac-nav-menu-list-item{nav_active("support.html")}
+          %a{href: "support.html", title: "Support", :data => {:path => "support.html"}} Support
         %li.ac-nav-menu-list-icon
           %a.ac-icon{href: "https://github.com/algolia/places", title: "GitHub repository"}
             %span.ac-icon.ac-icon-github

--- a/docs/source/support.html.md
+++ b/docs/source/support.html.md
@@ -1,0 +1,33 @@
+---
+title: Support
+layout: documentation
+---
+
+## Need help?
+
+Algolia Places is built by [Algolia's people](https://github.com/orgs/algolia/people). We are here to help you with any issues you would face while using Algolia Places.
+
+### Irrelevant results
+
+Should the Places suggestions appear irrelevant, <a href="https://docs.google.com/forms/d/13r_7B72v6u6326atqzKZpv0fs_3OUOJFR-6QDipHl3Y/viewform?entry.1560244398&entry.1894094686&entry.1809496416&entry.2029760924&entry.1442423869&entry.1714224469&entry.1070945708=Find+it+on+https://api.ipify.org/&entry.2019626860=Find+it+on+https://jsfiddle.net/qmjet97b/" id="support-google-form" target="_blank">let us know via our dedicated form</a>.
+
+### places.js bugs
+
+The whole Algolia Places JavaScript library and website are available on github.
+
+If you have any issue while using places.js, [search for a corresponding issue](https://github.com/algolia/places/issues?utf8=%E2%9C%93&q=is%3Aissue)
+first.
+
+If you do not find any corresponding issue, [open a new one](https://github.com/algolia/places/issues/new) describing your problem in simple words.
+
+## Coding help
+
+The easiest way to get some coding advices is to ask your question on [Stack Overflow](https://stackoverflow.com/),
+our community of users will be happy to help you there.
+
+<script>
+  function getip(res) {
+    window.userip = res.ip;
+  }
+</script>
+<script src="https://api.ipify.org?format=jsonp&callback=getip"></script>


### PR DESCRIPTION
This is a proposal on the support part. I do like when Support is easily reachable.

I think every community project should provide this support menu entry to be transparent on where can you get support (github, stackoverflow, email, ..).

There's some custom code to link to a google form with prefilled values for IP address and geolocation.

It handles failures where any of those values is not available and provide fallbacks (we ask the user to go on myip.. etc)