### PR TITLE
docs(samples): remove pointer events on maps

### DIFF
--- a/docs/source/partials/examples/_instantsearch.html.erb
+++ b/docs/source/partials/examples/_instantsearch.html.erb
@@ -2,7 +2,10 @@
 <div id="map-instantsearch-container"></div>
 
 <style>
-  #map-instantsearch-container {height: 300px};
+  #map-instantsearch-container {
+    height: 300px;
+    pointer-events: none;
+  };
 </style>
 
 <%= javascript_include_tag config[:instantsearch_lib_url] %>

--- a/docs/source/partials/examples/_map.html.erb
+++ b/docs/source/partials/examples/_map.html.erb
@@ -2,7 +2,7 @@
 <input type="search" id="input-map" class="form-control" placeholder="Where are we going?" />
 
 <style>
-  #map-example-container {height: 300px};
+  #map-example-container {height: 300px; pointer-events: none;};
 </style>
 
 <%= javascript_include_tag config[:places_lib_url] %>

--- a/docs/source/partials/examples/_map_paris.html.erb
+++ b/docs/source/partials/examples/_map_paris.html.erb
@@ -3,7 +3,8 @@
 
 <style>
   #map-example-container-paris {
-    height: 300px
+    height: 300px;
+    pointer-events: none;
   }
 </style>
 


### PR DESCRIPTION
Practical to be able to scroll over the maps. Not cool as it kinda kill
any interactions with google maps instantsearch sample. Not option is
available in instantsearch-googlemaps widget to achieve a middle ground
:(

Do we want that or not?