### PR TITLE
fix(initialization): Swap appId and apiKey

### DIFF
--- a/src/createAutocompleteSource.js
+++ b/src/createAutocompleteSource.js
@@ -18,8 +18,8 @@ export default function createAutocompleteSource({
   type
 }) {
   const placesClient = algoliasearch.initPlaces(
-    apiKey,
     appId,
+    apiKey,
     clientOptions
   );
   placesClient.as.addAlgoliaAgent(`Algolia Places ${version}`);


### PR DESCRIPTION
Authenticated requests would fail because of the two credentials being inverted.