### PR TITLE
fix(meteorjs): lite build must point to the browser lite

### DIFF
--- a/src/places.js
+++ b/src/places.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import algoliasearch from 'algoliasearch/lite.js';
+import algoliasearch from 'algoliasearch/src/browser/builds/algoliasearchLite.js';
 import autocomplete from 'autocomplete.js';
 
 import './navigatorLanguage.js';


### PR DESCRIPTION
fixes algolia/places#349

based on algolia/instantsearch.js#1097 PR