### PR TITLE
fix(appearance) don't show clear button on IE11

### DIFF
--- a/docs/source/stylesheets/vendors/_normalize.scss
+++ b/docs/source/stylesheets/vendors/_normalize.scss
@@ -415,10 +415,14 @@ textarea {
 
 /**
  * Remove the inner padding and cancel buttons in Chrome on OS X and
- * Safari on OS X.
+ * Safari on OS X, and IE11+
  */
 
 [type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
+}
+
+[type="search"]::-ms-clear {
+    display: none;
 }

--- a/docs/source/stylesheets/vendors/_normalize.scss
+++ b/docs/source/stylesheets/vendors/_normalize.scss
@@ -424,5 +424,5 @@ textarea {
 }
 
 [type="search"]::-ms-clear {
-    display: none;
+  display: none;
 }


### PR DESCRIPTION
**Summary**

fixes #389

Same reason as why the icon is hidden on Safari and Chrome

**Result**

I don't have a screenshot since I didn't open a VM, but I'm pretty sure that this will work

sources: 

* https://developer.mozilla.org/en-US/docs/Web/CSS/::-ms-clear
* https://msdn.microsoft.com/en-us/library/windows/apps/hh465740.aspx