### PR TITLE
fix(layout) hide the browser clear buttons

### DIFF
--- a/src/places.css
+++ b/src/places.css
@@ -14,6 +14,14 @@
   font: inherit;
 }
 
+.ap-input::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.ap-input::-ms-clear {
+  display: none;
+}
+
 .ap-input:hover ~ .ap-input-icon svg,
 .ap-input:focus ~ .ap-input-icon svg,
 .ap-input-icon:hover svg {


### PR DESCRIPTION
**Summary**
Hide the browser native input type search decoration.

I'm not sure why this wasn't already the case, but we probably never noticed it because it was in our normalise css.

cc @lukyvj @shipow

fixes #389 for real now

**Result**

No browser clear button will be visible.