### PR TITLE
Fix link in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Hi (future) collaborator!
 
 **tl;dr;**
 - use pull requests
-- use [conventional changelog](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md) commit style messages
+- use [conventional changelog](https://github.com/conventional-changelog/conventional-changelog) commit style messages
 - squash your commits
 - have fun
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Hi (future) collaborator!
 
 **tl;dr;**
 - use pull requests
-- use [conventional changelog](https://github.com/conventional-changelog/conventional-changelog) commit style messages
+- use [conventional changelog](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/convention.md) commit style messages
 - squash your commits
 - have fun
 


### PR DESCRIPTION
Link for conventional changelog is giving 404. Updating it to the correct one (if I'm not mistaken...)