### PR TITLE
docs(backend): Add PHP backend example

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -713,6 +713,23 @@ This position is an array of two numbers, representing the lattitude and the lon
     </tbody>
     </table>
 
+### Backend
+
+You can also query the Places API from your backend, here is an example with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php). It requires a registered [Places account](https://www.algolia.com/users/sign_up/places).
+
+```php
+<?php
+$appId = 'YOUR_PLACES_APP_ID';
+$apiKey = 'YOUR_PLACES_API_KEY';
+
+$client = new \AlgoliaSearch\Client($appId, $apiKey);
+$places = $client->initPlaces($appId, $apiKey);
+
+$data = json_encode(array('query' => 'Paris'));
+$result = $places->search($data);
+var_dump($result);
+```
+
 ### REST API
 
 Behind the places.js the JavaScript library lies a complete REST API. Read the underlying [REST API documentation](rest.html).

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -713,9 +713,29 @@ This position is an array of two numbers, representing the lattitude and the lon
     </tbody>
     </table>
 
-### Backend
+### JavaScript API Client
 
-You can also query the Places API from your backend, here is an example with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php). 
+You can directly query the [Places REST API](rest.html) using our [JavaScript API client](https://github.com/algolia/algoliasearch-client-javascript),
+either in browsers or with [Node.js](https://nodejs.org/).
+
+
+
+```js
+// var algoliasearch = require('algoliasearch');
+var places = algoliasearch.initPlaces(/*appId, apiKey*/);
+places
+  .search(/*{REST API Params}*/, function(err, res) {
+    if (err) {
+      throw err;
+    }
+    console.log(res);
+  });
+```
+
+### PHP API Client
+
+You can directly query the [Places REST API](rest.html) with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php),
+so that you can do backend Places searches.
 
 Without credentials (require PHP API Client >= 1.18.0):
 

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -725,8 +725,7 @@ $apiKey = 'YOUR_PLACES_API_KEY';
 $client = new \AlgoliaSearch\Client($appId, $apiKey);
 $places = $client->initPlaces($appId, $apiKey);
 
-$data = json_encode(array('query' => 'Paris'));
-$result = $places->search($data);
+$result = $places->search('Paris');
 var_dump($result);
 ```
 

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -715,15 +715,28 @@ This position is an array of two numbers, representing the lattitude and the lon
 
 ### Backend
 
-You can also query the Places API from your backend, here is an example with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php). It requires a registered [Places account](https://www.algolia.com/users/sign_up/places).
+You can also query the Places API from your backend, here is an example with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php). 
+
+Without credentials (require PHP API Client >= 1.18.0):
 
 ```php
 <?php
+
+$places = \AlgoliaSearch\Client::initPlaces();
+
+$result = $places->search('Paris');
+var_dump($result);
+```
+
+With credentials, requires a registered [Places account](https://www.algolia.com/users/sign_up/places).
+
+```php
+<?php
+
 $appId = 'YOUR_PLACES_APP_ID';
 $apiKey = 'YOUR_PLACES_API_KEY';
 
-$client = new \AlgoliaSearch\Client($appId, $apiKey);
-$places = $client->initPlaces($appId, $apiKey);
+$places = \AlgoliaSearch\Client::initPlaces($appId, $apiKey);
 
 $result = $places->search('Paris');
 var_dump($result);


### PR DESCRIPTION
This adds a code example on how to use initPlaces() with the PHP API
Client to do a Places call. I think it only works with registered
account, I could not make it work without credentials.

![image](https://cloud.githubusercontent.com/assets/283419/26103315/2e7ba040-3a39-11e7-8bc1-f4fed7767081.png)
