### PR TITLE
fix(css): override the appearance of the input

### DIFF
--- a/src/places.css
+++ b/src/places.css
@@ -12,6 +12,8 @@
   border-radius: 3px;
   outline: none;
   font: inherit;
+  appearance: none;
+  -webkit-appearance: none;
 }
 
 .ap-input::-webkit-search-decoration {


### PR DESCRIPTION
The native appearance of the searchbar on Safari will stay 11px, while if you do `-webkit-appearance: none` it will grow appropriately

before|after
---|---
<img width="1680" alt="screen shot 2017-07-29 at 20 06 06" src="https://user-images.githubusercontent.com/6270048/28747199-9d40c538-7499-11e7-9632-9d69391a518c.png">|<img width="1680" alt="screen shot 2017-07-29 at 20 06 13" src="https://user-images.githubusercontent.com/6270048/28747198-9d27308c-7499-11e7-846e-9d92db228d7f.png">


https://codepen.io/Haroenv/pen/mMVOPP

This bubbles down to default implementations like https://🌚🌞.ws too 