### PR TITLE
docs(autocomplete): fixing example to correctly return suggestion from rental set

### DIFF
--- a/docs/source/partials/examples/_autocomplete_dataset.html.erb
+++ b/docs/source/partials/examples/_autocomplete_dataset.html.erb
@@ -58,13 +58,11 @@
     templates: {
       header: '<div class="ad-example-header">Vacation rentals</div>',
       suggestion: function(suggestion) {
-        return '<div class="ad-example-suggestion">' +
-          '<img src="' + suggestion.thumbnail_url + '" />' +
+        return '<img src="' + suggestion.thumbnail_url + '" />' +
           '<div>' +
             suggestion._highlightResult.name.value + '<br />' +
             '<small>' + suggestion._highlightResult.city.value + '</small>' +
-          '</div>' +
-          '</div>';
+         '</div>';
       }
     }
   };


### PR DESCRIPTION
**Summary**
Fixes Autocomplete example bug described here https://github.com/algolia/places/issues/427#issuecomment-325460194

**Result**
When rentalDataset gets selected or autocompleted, suggestion is correctly now passed to event handler.

fixes #427
