### PR TITLE
fix(contact): force language to be English to avoid contact misses

### DIFF
--- a/docs/source/contact.html.haml
+++ b/docs/source/contact.html.haml
@@ -75,6 +75,7 @@ subtitle: Turn any <code>&lt;input&gt;</code> into an address autocomplete
     var placesAutocomplete = places({
       container: document.querySelector('#country'),
       type: 'country',
+      language: 'en',
       templates: {
         suggestion: function(suggestion) {
           return '<i class="flag ' + suggestion.countryCode + '"></i> ' +


### PR DESCRIPTION
SFDC doesn't sync well with non-english names hence potential contacts loss.