### PR TITLE
fix(docs) - Fixed latitude/longitude typos

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -185,7 +185,7 @@ default.
 Type: **number**
 </td>
 <td markdown="1">
-Radius in meters to search around the latitude longitutde. Otherwise a default radius is automatically computed
+Radius in meters to search around the latitude longitude. Otherwise a default radius is automatically computed
 given the area density.
 </td>
     </tr>
@@ -733,7 +733,7 @@ Type: **number[]**
 </td>
 <td markdown="1">
 Sets the default position around which the instantsearch search is done, when no element is selected in the places widget.
-This position is an array of two numbers, representing the lattitude and the longitude.
+This position is an array of two numbers, representing the latitude and the longitude.
 </td>
     </tr>
     </tbody>

--- a/docs/source/rest.html.md.erb
+++ b/docs/source/rest.html.md.erb
@@ -141,7 +141,7 @@ default.
 Type: number
 </td>
 <td markdown="1">
-Radius in meters to search around the latitude/longitutde. Otherwise a default radius is automatically computed
+Radius in meters to search around the latitude/longitude. Otherwise a default radius is automatically computed
 given the area density.
 </td>
     </tr>


### PR DESCRIPTION
I found three small typos in the docs, and here's a fix! 