### PR TITLE
feat(InstantSearchWidget): clear the boundingBox when perform a search

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "repository": "https://github.com/algolia/places",
   "license": "MIT",
   "devDependencies": {
+    "algoliasearch-helper": "^2.23.2",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -11,15 +11,24 @@ class AlgoliaPlacesWidget {
   init({ helper }) {
     const placesAutocomplete = places(this.placesOptions);
 
-    helper.setQueryParameter('aroundLatLng', this.defaultPosition);
+    helper
+      .setQueryParameter('insideBoundingBox')
+      .setQueryParameter('aroundLatLng', this.defaultPosition);
 
     placesAutocomplete.on('change', opts => {
       const { suggestion: { latlng: { lat, lng } } } = opts;
-      helper.setQueryParameter('aroundLatLng', `${lat},${lng}`).search();
+
+      helper
+        .setQueryParameter('insideBoundingBox')
+        .setQueryParameter('aroundLatLng', `${lat},${lng}`)
+        .search();
     });
 
     placesAutocomplete.on('clear', () => {
-      helper.setQueryParameter('aroundLatLng', this.defaultPosition).search();
+      helper
+        .setQueryParameter('insideBoundingBox')
+        .setQueryParameter('aroundLatLng', this.defaultPosition)
+        .search();
     });
   }
 }

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -34,12 +34,14 @@ describe('instantsearch widget', () => {
   it('configures the helper', () => {
     const widget = algoliaPlacesWidget(defaultOptions);
     widget.init({ helper });
+    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
     expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '0,0');
   });
 
   it('accepts a defaultPosition parameter', () => {
     const widget = algoliaPlacesWidget({ defaultPosition: [1, 1] });
     widget.init({ helper });
+    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
     expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '1,1');
   });
 
@@ -47,10 +49,13 @@ describe('instantsearch widget', () => {
     const widget = algoliaPlacesWidget(defaultOptions);
     widget.init({ helper });
 
+    helper.setQueryParameter.mockClear();
+
     const eventName = places.__instance.on.mock.calls[0][0];
     const eventListener = places.__instance.on.mock.calls[0][1];
     expect(eventName).toEqual('change');
     eventListener({ suggestion: { latlng: { lat: '123', lng: '456' } } });
+    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
     expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '123,456');
     expect(helper.search).toBeCalled();
   });
@@ -59,10 +64,13 @@ describe('instantsearch widget', () => {
     const widget = algoliaPlacesWidget({ defaultPosition: [2, 2] });
     widget.init({ helper });
 
+    helper.setQueryParameter.mockClear();
+
     const eventName = places.__instance.on.mock.calls[1][0];
     const eventListener = places.__instance.on.mock.calls[1][1];
     expect(eventName).toEqual('clear');
     eventListener();
+    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
     expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '2,2');
     expect(helper.search).toBeCalled();
   });

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -1,3 +1,7 @@
+import searchHelper from 'algoliasearch-helper';
+import algoliaPlacesWidget from './widget.js';
+import places from '../places.js';
+
 jest.mock('../places.js', () => {
   const module = jest.fn(() => {
     const instance = { on: jest.fn() };
@@ -9,69 +13,98 @@ jest.mock('../places.js', () => {
   return module;
 });
 
-import algoliaPlacesWidget from './widget.js';
-import places from '../places.js';
+const createFakeClient = () => ({
+  addAlgoliaAgent: () => {},
+});
+
+const createFakekHelper = client => {
+  const helper = searchHelper(client);
+
+  helper.search = jest.fn();
+
+  return helper;
+};
 
 describe('instantsearch widget', () => {
-  let helper;
   const defaultOptions = {
     places: 'option',
   };
 
-  beforeEach(() => {
-    helper = {
-      setQueryParameter: jest.fn().mockReturnThis(),
-      search: jest.fn().mockReturnThis(),
-    };
-  });
-
   it('creates a places instance', () => {
+    const client = createFakeClient();
+    const helper = createFakekHelper(client);
     const widget = algoliaPlacesWidget(defaultOptions);
+
     widget.init({ helper });
+
     expect(places).toBeCalledWith({ places: 'option' });
   });
 
   it('configures the helper', () => {
+    const client = createFakeClient();
+    const helper = createFakekHelper(client);
     const widget = algoliaPlacesWidget(defaultOptions);
+
     widget.init({ helper });
-    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
-    expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '0,0');
+
+    expect(helper.getState()).toMatchObject({
+      insideBoundingBox: undefined,
+      aroundLatLng: '0,0',
+    });
   });
 
   it('accepts a defaultPosition parameter', () => {
+    const client = createFakeClient();
+    const helper = createFakekHelper(client);
     const widget = algoliaPlacesWidget({ defaultPosition: [1, 1] });
+
     widget.init({ helper });
-    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
-    expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '1,1');
+
+    expect(helper.getState()).toMatchObject({
+      insideBoundingBox: undefined,
+      aroundLatLng: '1,1',
+    });
   });
 
   it('configures aroundLatLng on change event', () => {
+    const client = createFakeClient();
+    const helper = createFakekHelper(client);
     const widget = algoliaPlacesWidget(defaultOptions);
-    widget.init({ helper });
 
-    helper.setQueryParameter.mockClear();
+    widget.init({ helper });
 
     const eventName = places.__instance.on.mock.calls[0][0];
     const eventListener = places.__instance.on.mock.calls[0][1];
+
     expect(eventName).toEqual('change');
+
     eventListener({ suggestion: { latlng: { lat: '123', lng: '456' } } });
-    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
-    expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '123,456');
+
     expect(helper.search).toBeCalled();
+    expect(helper.getState()).toMatchObject({
+      insideBoundingBox: undefined,
+      aroundLatLng: '123,456',
+    });
   });
 
   it('configures aroundLatLng on clear event', () => {
+    const client = createFakeClient();
+    const helper = createFakekHelper(client);
     const widget = algoliaPlacesWidget({ defaultPosition: [2, 2] });
-    widget.init({ helper });
 
-    helper.setQueryParameter.mockClear();
+    widget.init({ helper });
 
     const eventName = places.__instance.on.mock.calls[1][0];
     const eventListener = places.__instance.on.mock.calls[1][1];
+
     expect(eventName).toEqual('clear');
+
     eventListener();
-    expect(helper.setQueryParameter).toBeCalledWith('insideBoundingBox');
-    expect(helper.setQueryParameter).toBeCalledWith('aroundLatLng', '2,2');
+
     expect(helper.search).toBeCalled();
+    expect(helper.getState()).toMatchObject({
+      insideBoundingBox: undefined,
+      aroundLatLng: '2,2',
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,15 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+algoliasearch-helper@^2.23.2:
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-2.23.2.tgz#8a45db4338cf7d54ade4a54d704bef7559e13a6a"
+  dependencies:
+    events "^1.1.0"
+    lodash "^4.13.1"
+    qs "^6.2.1"
+    util "^0.10.3"
+
 algoliasearch@^3.22.1, algoliasearch@^3.24.0:
   version "3.24.0"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.24.0.tgz#d0a6ac2963b781d2fb059a3a853fe18765673346"
@@ -3552,7 +3561,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4325,6 +4334,10 @@ punycode@^1.2.4, punycode@^1.4.1:
 q@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
+
+qs@^6.2.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 qs@~6.4.0:
   version "6.4.0"


### PR DESCRIPTION
**Summary**

When the widget InstantSearch Places set the position, it should clear the parameters who take predescence on it (ex: `insideBoudingBox`). Means that when we use the widget with a map, the current position of the map will be updated from Places position instead of keeping the current bounding box.