### PR TITLE
feat(suggestion): expose suburb field from API in suggestion

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -605,6 +605,21 @@ Examples:
     </tr>
     <tr>
 <td markdown="1">
+<div class="api-entry" id="api-suggestion-suburb"><code>suburb</code></div>
+
+Type: **string**
+</td>
+<td markdown="1">
+Suburb name.
+
+Examples:
+
+ - Angelino heights
+ - Harbor City
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
 <div class="api-entry" id="api-suggestion-latlng"><code>latlng</code></div>
 
 Type: **Object**

--- a/src/formatHit.js
+++ b/src/formatHit.js
@@ -46,6 +46,9 @@ export default function formatHit({
       ? hit.administrative[0]
       : undefined;
     const city = hit.city && hit.city[0] !== name ? hit.city[0] : undefined;
+    const suburb = hit.suburb && hit.suburb[0] !== name
+      ? hit.suburb[0]
+      : undefined;
 
     const highlight = {
       name: getBestHighlightedForm(hit._highlightResult.locale_names),
@@ -56,12 +59,16 @@ export default function formatHit({
         ? getBestHighlightedForm(hit._highlightResult.administrative)
         : undefined,
       country: country ? hit._highlightResult.country.value : undefined,
+      suburb: suburb
+        ? getBestHighlightedForm(hit._highlightResult.suburb)
+        : undefined,
     };
 
     const suggestion = {
       name,
       administrative,
       city,
+      suburb,
       country,
       countryCode: findCountryCode(hit._tags),
       type: findType(hit._tags),

--- a/src/formatHit.test.js
+++ b/src/formatHit.test.js
@@ -38,6 +38,46 @@ describe('formatHit', () => {
       },
     }),
     getTestCase({
+      name: 'no suburb',
+      hit: { suburb: undefined },
+      expected: {
+        suburb: undefined,
+        highlight: { suburb: undefined },
+      },
+    }),
+    getTestCase({
+      name: 'suburb[0] === locale_names[0]',
+      hit: {
+        suburb: ['Harbor City'],
+        locale_names: ['Harbor City'],
+        _highlightResult: {
+          locale_names: [{ value: 'Harbor City' }],
+          suburb: [{ value: 'Harbor City' }],
+        },
+      },
+      expected: {
+        suburb: undefined,
+        name: 'Harbor City',
+        highlight: { suburb: undefined, name: 'Harbor City' },
+      },
+    }),
+    getTestCase({
+      name: 'suburb[0] !== locale_names[0]',
+      hit: {
+        suburb: ['Harbor City'],
+        locale_names: ['237th Street'],
+        _highlightResult: {
+          locale_names: [{ value: '237th Street' }],
+          suburb: [{ value: 'Harbor City' }],
+        },
+      },
+      expected: {
+        suburb: 'Harbor City',
+        name: '237th Street',
+        highlight: { suburb: 'Harbor City', name: '237th Street' },
+      },
+    }),
+    getTestCase({
       name: 'locale_names[1] is matching',
       hit: {
         locale_names: ['Paris', 'Lutèce'],
@@ -156,6 +196,7 @@ describe('formatHit', () => {
         name: output.name,
         administrative: output.administrative,
         city: output.city,
+        suburb: output.suburb,
         country: output.country,
         countryCode: output.countryCode,
         type: output.type,


### PR DESCRIPTION
**Summary**
This PR exposes the suburb field that is available from the API.
In some countries like Australia, the city field is not sufficient to get an accurate address and the suburb field should be used.

For instance, `1 perth old road` would yield `Perth, Western Australia, Australia`, while locals would expect either `Bassendean, Western Australia, Australia` or `Bassendean, Perth, Western Australia, Australia`.

This PR fixes #337.

**Note:**
This PR does not modify the `formatDropdownValue` or `formatInputValue`, it only exposes the `suburb` field in `suggestion`. formatting using the suburb field is left to the implementor.

**Result**
http://plnkr.co/edit/suBWvwZGtUhMM4C5qN8J?p=preview
Try with `1 perth old road` for example.
