### PR TITLE
fix(css): add border-box to .ap-input (#472)

### DIFF
--- a/src/places.css
+++ b/src/places.css
@@ -14,6 +14,7 @@
   font: inherit;
   appearance: none;
   -webkit-appearance: none;
+  box-sizing: border-box;
 }
 
 .ap-input::-webkit-search-decoration {


### PR DESCRIPTION
**Summary**
Add box-sizing: border-box to avoid input field override parent 100% width. Solves #472 