### PR TITLE
Fix missing flags

### DIFF
--- a/docs/source/contact.html.haml
+++ b/docs/source/contact.html.haml
@@ -3,7 +3,7 @@ title: Algolia Places
 subtitle: Turn any <code>&lt;input&gt;</code> into an address autocomplete
 ---
 
-%link{:rel =>"stylesheet", :type => "text/css",  :href => "//cloud.github.com/downloads/lafeber/world-flags-sprite/flags16.css"}
+%link{:rel =>"stylesheet", :type => "text/css",  :href => "//github.com/downloads/lafeber/world-flags-sprite/flags16.css"}
 
 %section.examples-section
   .container

--- a/docs/source/partials/examples/_country_search.html.erb
+++ b/docs/source/partials/examples/_country_search.html.erb
@@ -1,4 +1,4 @@
-<link rel="stylesheet" type="text/css" href="//cloud.github.com/downloads/lafeber/world-flags-sprite/flags16.css" />
+<link rel="stylesheet" type="text/css" href="//github.com/downloads/lafeber/world-flags-sprite/flags16.css" />
 
 <div class="f16">
   <input type="search" id="country" class="form-control" placeholder="What's your favorite country?" />


### PR DESCRIPTION
<img width="431" alt="screen shot 2018-05-09 at 3 27 07 pm" src="https://user-images.githubusercontent.com/783964/39817089-78e29a16-539d-11e8-8d81-b604269ae630.png">
^ Flag images are missing. The URL apparently doesn't exist anymore.