### PR TITLE
Feat/county: expose the county field in places.js

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -605,6 +605,21 @@ Examples:
     </tr>
     <tr>
 <td markdown="1">
+<div class="api-entry" id="api-suggestion-county"><code>county</code></div>
+
+Type: **string**
+</td>
+<td markdown="1">
+County level administrative region depending on the country.
+
+Examples:
+
+ - Corrèze
+ - Clark County
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
 <div class="api-entry" id="api-suggestion-suburb"><code>suburb</code></div>
 
 Type: **string**

--- a/src/formatHit.js
+++ b/src/formatHit.js
@@ -50,6 +50,10 @@ export default function formatHit({
       ? hit.suburb[0]
       : undefined;
 
+    const county = hit.county && hit.county[0] !== name
+      ? hit.county[0]
+      : undefined;
+
     const highlight = {
       name: getBestHighlightedForm(hit._highlightResult.locale_names),
       city: city
@@ -62,11 +66,15 @@ export default function formatHit({
       suburb: suburb
         ? getBestHighlightedForm(hit._highlightResult.suburb)
         : undefined,
+      county: county
+        ? getBestHighlightedForm(hit._highlightResult.county)
+        : undefined,
     };
 
     const suggestion = {
       name,
       administrative,
+      county,
       city,
       suburb,
       country,

--- a/src/formatHit.test.js
+++ b/src/formatHit.test.js
@@ -155,6 +155,23 @@ describe('formatHit', () => {
       },
     }),
     getTestCase({
+      name: 'county[0] === locale_names[0]',
+      hit: {
+        county: ['Paris'],
+        locale_names: ['Paris'],
+        _highlightResult: {
+          locale_names: [{ value: 'Paris' }],
+          city: [{ value: 'Paris' }],
+        },
+      },
+      expected: {
+        city: undefined,
+        county: undefined,
+        name: 'Paris',
+        highlight: { city: undefined, name: 'Paris', county: undefined },
+      },
+    }),
+    getTestCase({
       name: 'no country',
       hit: {
         country: undefined,
@@ -199,6 +216,7 @@ describe('formatHit', () => {
         suburb: output.suburb,
         country: output.country,
         countryCode: output.countryCode,
+        county: output.county,
         type: output.type,
         latlng: output.latlng,
         postcode: output.postcode,
@@ -227,6 +245,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
     country: 'France',
     administrative: ['Île-de-France'],
     city: ['Paris'],
+    county: ['County of Paris'],
     _geoloc: {
       lat: '123',
       lng: '456',
@@ -236,6 +255,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
     _highlightResult: {
       locale_names: [{ value: 'Paris' }],
       city: [{ value: 'Paris' }],
+      county: [{ value: 'County of Paris' }],
       administrative: [{ value: 'Île-de-France' }],
       country: { value: 'France' },
     },
@@ -244,6 +264,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
   const defaultExpected = {
     name: 'rue de rivoli',
     administrative: 'Île-de-France',
+    county: 'County of Paris',
     city: 'Paris',
     country: 'France',
     latlng: {
@@ -259,6 +280,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
       city: 'Paris',
       administrative: 'Île-de-France',
       country: 'France',
+      county: 'County of Paris',
     },
   };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Exposes the `county` field in the suggestion object.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
```
{
  administrative: "Nouvelle-Aquitaine",
  city: undefined,
  country: "France",
  countryCode: "fr",
  county: "Corrèze",
  latlng: {lat: 45.1589, lng: 1.53318},
  name: "Brive-la-Gaillarde",
  postcode: "19100",
  suburb: undefined,
  type: "city"
}
```

![image](https://user-images.githubusercontent.com/5136989/40124637-43edfecc-5929-11e8-98e7-2c095dc36e63.png)


**Important:** This PR does not modify the default format, it only exposes the county field that was available through the REST API