### PR TITLE
fix(default-location): don't default to [0,0] for defaultLocation

### DIFF
--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -4,7 +4,7 @@ import places from '../places.js';
  * The underlying structure for the Algolia Places instantsearch widget.
  */
 class AlgoliaPlacesWidget {
-  constructor({ defaultPosition = [0, 0], ...placesOptions }) {
+  constructor({ defaultPosition = [], ...placesOptions }) {
     this.defaultPosition = defaultPosition.join(',');
     this.placesOptions = placesOptions;
   }

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -49,7 +49,7 @@ describe('instantsearch widget', () => {
 
     expect(helper.getState()).toMatchObject({
       insideBoundingBox: undefined,
-      aroundLatLng: '0,0',
+      aroundLatLng: '',
     });
   });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
This changes the defaultLocation parameter in the places IS widget from`[0,0]` to `[]` (which is transformed into `''` instead of `0,0`).
Therefore in a clear state, there are no `aroundLatLng` parameter, and the geosearch ranking is not applied with a possibly irrelevant `[0,0]` coordinate, and lets the standard business logic take over.
