### PR TITLE
fix(viaIP-conflict): disable aroundLatLngViaIP when setting location

### DIFF
--- a/src/instantsearch/__snapshots__/widget.test.js.snap
+++ b/src/instantsearch/__snapshots__/widget.test.js.snap
@@ -7,7 +7,7 @@ SearchParameters {
   "analytics": undefined,
   "analyticsTags": undefined,
   "aroundLatLng": "123,123",
-  "aroundLatLngViaIP": undefined,
+  "aroundLatLngViaIP": false,
   "aroundPrecision": undefined,
   "aroundRadius": undefined,
   "attributesToHighlight": undefined,

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -27,6 +27,8 @@ class AlgoliaPlacesWidget {
   }
 
   init({ helper }) {
+    const viaIPFlag = helper.getQueryParameter('aroundLatLngViaIP');
+
     this.placesAutocomplete.on('change', opts => {
       const {
         suggestion: {
@@ -38,6 +40,7 @@ class AlgoliaPlacesWidget {
       this.query = value;
       helper
         .setQueryParameter('insideBoundingBox')
+        .setQueryParameter('aroundLatLngViaIP', false)
         .setQueryParameter('aroundLatLng', `${lat},${lng}`)
         .search();
     });
@@ -46,6 +49,7 @@ class AlgoliaPlacesWidget {
       this.query = '';
       helper
         .setQueryParameter('insideBoundingBox')
+        .setQueryParameter('aroundLatLngViaIP', viaIPFlag)
         .setQueryParameter('aroundLatLng', this.defaultPosition)
         .search();
     });

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -4,7 +4,7 @@ import places from '../places.js';
  * The underlying structure for the Algolia Places instantsearch widget.
  */
 class AlgoliaPlacesWidget {
-  constructor({ defaultPosition, ...placesOptions }) {
+  constructor({ defaultPosition, ...placesOptions } = {}) {
     if (Array.isArray(defaultPosition) && defaultPosition.length === 2) {
       this.defaultPosition = defaultPosition.join(',');
     }

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -40,6 +40,10 @@ describe('instantsearch widget', () => {
     expect(places).toBeCalledWith({ places: 'option' });
   });
 
+  it('creates a places instance without parameters', () => {
+    expect(() => algoliaPlacesWidget()).not.toThrow();
+  });
+
   it('configures the helper', () => {
     const client = createFakeClient();
     const helper = createFakekHelper(client);


### PR DESCRIPTION
**Summary**
When using the Places Widget in coordination with other geolocation widget such as the Geosearch, there can be a conflict between the `aroundLatLngViaIP:true` field and the `aroundLatLng` set by Places.

**Result**
`aroundLatLngViaIP` is set to `false` when a user selects a geolocation through places. It is restored to its initial value on clear.
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
