### PR TITLE
Chore/enforce-node-ver

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,6 +4,12 @@ set -e # exit when error
 
 printf "\nReleasing\n"
 
+if [ "$(node -v)" != "v$(cat .nvmrc)" ]
+  then
+  printf "Release: Node version mismatch with .nvmrc (should be $(cat .nvmrc))\n"
+  exit 1
+fi
+
 if ! npm owner ls | grep -q "$(npm whoami)"
 then
   printf "Release: Not an owner of the npm repo, ask a contributor for access"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,18 +12,18 @@ fi
 
 if ! npm owner ls | grep -q "$(npm whoami)"
 then
-  printf "Release: Not an owner of the npm repo, ask a contributor for access"
+  printf "Release: Not an owner of the npm repo, ask a contributor for access\n"
   exit 1
 fi
 
 currentBranch=`git rev-parse --abbrev-ref HEAD`
 if [ $currentBranch != 'master' ]; then
-  printf "Release: You must be on master"
+  printf "Release: You must be on master\n"
   exit 1
 fi
 
 if [[ -n $(git status --porcelain) ]]; then
-  printf "Release: Working tree is not clean (git status)"
+  printf "Release: Working tree is not clean (git status)\n"
   exit 1
 fi
 


### PR DESCRIPTION
**Summary**
This PR adds an assertion that the node version used to do the release matches the one set in `.nvmrc`.

It is the first check that is done by the release script.

**Result**
With a bad node version:
![image](https://user-images.githubusercontent.com/5136989/43840021-e4190850-9b1f-11e8-874e-4fa910786636.png)

With a good node version (fails after):
![image](https://user-images.githubusercontent.com/5136989/43840112-1caf5c00-9b20-11e8-8357-39e627212065.png)
