### PR TITLE
Fix/routing-pagination

### DIFF
--- a/src/instantsearch/__snapshots__/widget.test.js.snap
+++ b/src/instantsearch/__snapshots__/widget.test.js.snap
@@ -57,13 +57,13 @@ SearchParameters {
 }
 `;
 
-exports[`instantsearch widget routing getWidgetSearchParameters should enforce the default value if no value is in the UI State 1`] = `
+exports[`instantsearch widget routing getWidgetSearchParameters should not care about the default value even if no value is in the UI State 1`] = `
 SearchParameters {
   "advancedSyntax": undefined,
   "allowTyposOnNumericTokens": undefined,
   "analytics": undefined,
   "analyticsTags": undefined,
-  "aroundLatLng": "2,2",
+  "aroundLatLng": undefined,
   "aroundLatLngViaIP": undefined,
   "aroundPrecision": undefined,
   "aroundRadius": undefined,

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -5,7 +5,7 @@ import places from '../places.js';
  */
 class AlgoliaPlacesWidget {
   constructor({ defaultPosition, ...placesOptions }) {
-    if (defaultPosition instanceof Array && defaultPosition.length === 2) {
+    if (Array.isArray(defaultPosition) && defaultPosition.length === 2) {
       this.defaultPosition = defaultPosition.join(',');
     }
 

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -12,7 +12,7 @@ class AlgoliaPlacesWidget {
     this.placesOptions = placesOptions;
     this.placesAutocomplete = places(this.placesOptions);
 
-    this.state = {};
+    this.query = '';
   }
 
   init({ helper }) {
@@ -31,19 +31,15 @@ class AlgoliaPlacesWidget {
         },
       } = opts;
 
-      this.state.position = `${lat},${lng}`;
-      this.state.query = value;
-
+      this.query = value;
       helper
         .setQueryParameter('insideBoundingBox')
-        .setQueryParameter('aroundLatLng', this.state.position)
+        .setQueryParameter('aroundLatLng', `${lat},${lng}`)
         .search();
     });
 
     this.placesAutocomplete.on('clear', () => {
-      this.state.position = undefined;
-      this.state.query = undefined;
-
+      this.query = '';
       helper
         .setQueryParameter('insideBoundingBox')
         .setQueryParameter('aroundLatLng', this.defaultPosition)
@@ -59,7 +55,6 @@ class AlgoliaPlacesWidget {
 
     const { query, position } = uiState.places;
 
-    this.state = uiState.places;
     this.placesAutocomplete.setVal(query || '');
 
     return searchParameters
@@ -70,16 +65,13 @@ class AlgoliaPlacesWidget {
   getWidgetState(uiState, { searchParameters }) {
     if (
       uiState.places &&
-      this.state.query === uiState.places.query &&
+      this.query === uiState.places.query &&
       searchParameters.aroundLatLng === uiState.places.position
     ) {
       return uiState;
     }
 
-    if (
-      searchParameters.aroundLatLng === undefined &&
-      this.state.query === undefined
-    ) {
+    if (searchParameters.aroundLatLng === undefined && !this.query) {
       const newUiState = Object.assign({}, uiState);
       delete newUiState.places;
       return newUiState;
@@ -88,7 +80,7 @@ class AlgoliaPlacesWidget {
     return {
       ...uiState,
       places: {
-        query: this.state.query,
+        query: this.query,
         position: searchParameters.aroundLatLng,
       },
     };

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -60,6 +60,7 @@ class AlgoliaPlacesWidget {
 
     const { query, position } = uiState.places;
 
+    this.query = query;
     this.placesAutocomplete.setVal(query || '');
     this.placesAutocomplete.close();
 

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -12,17 +12,21 @@ class AlgoliaPlacesWidget {
     this.placesOptions = placesOptions;
     this.placesAutocomplete = places(this.placesOptions);
 
-    this.stateSetDuringRouting = false;
     this.query = '';
   }
 
-  init({ helper }) {
-    if (!this.stateSetDuringRouting) {
-      helper
-        .setQueryParameter('insideBoundingBox')
-        .setQueryParameter('aroundLatLng', this.defaultPosition);
+  getConfiguration() {
+    const configuration = {};
+
+    if (this.defaultPosition) {
+      configuration.aroundLatLng = this.defaultPosition;
+      configuration.insideBoundingBox = undefined;
     }
 
+    return configuration;
+  }
+
+  init({ helper }) {
     this.placesAutocomplete.on('change', opts => {
       const {
         suggestion: {
@@ -56,7 +60,6 @@ class AlgoliaPlacesWidget {
 
     const { query, position } = uiState.places;
 
-    this.stateSetDuringRouting = true;
     this.placesAutocomplete.setVal(query || '');
     this.placesAutocomplete.close();
 

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -50,6 +50,7 @@ class AlgoliaPlacesWidget {
   getWidgetSearchParameters(searchParameters, { uiState }) {
     if (!uiState.places) {
       this.placesAutocomplete.setVal('');
+      this.placesAutocomplete.close();
       return searchParameters;
     }
 
@@ -57,6 +58,7 @@ class AlgoliaPlacesWidget {
 
     this.stateSetDuringRouting = true;
     this.placesAutocomplete.setVal(query || '');
+    this.placesAutocomplete.close();
 
     return searchParameters
       .setQueryParameter('insideBoundingBox')

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -12,16 +12,16 @@ class AlgoliaPlacesWidget {
     this.placesOptions = placesOptions;
     this.placesAutocomplete = places(this.placesOptions);
 
+    this.stateSetDuringRouting = false;
     this.query = '';
   }
 
   init({ helper }) {
-    helper
-      .setQueryParameter('insideBoundingBox')
-      .setQueryParameter(
-        'aroundLatLng',
-        this.state.position || this.defaultPosition
-      );
+    if (!this.stateSetDuringRouting) {
+      helper
+        .setQueryParameter('insideBoundingBox')
+        .setQueryParameter('aroundLatLng', this.defaultPosition);
+    }
 
     this.placesAutocomplete.on('change', opts => {
       const {
@@ -55,6 +55,7 @@ class AlgoliaPlacesWidget {
 
     const { query, position } = uiState.places;
 
+    this.stateSetDuringRouting = true;
     this.placesAutocomplete.setVal(query || '');
 
     return searchParameters

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -54,16 +54,42 @@ describe('instantsearch widget', () => {
   });
 
   it('accepts a defaultPosition parameter', () => {
-    const client = createFakeClient();
-    const helper = createFakekHelper(client);
     const widget = algoliaPlacesWidget({ defaultPosition: [1, 1] });
 
-    widget.init({ helper });
+    const beforeConfiguration = {};
+    const afterConfiguration = widget.getConfiguration(beforeConfiguration);
 
-    expect(helper.getState()).toMatchObject({
+    expect(afterConfiguration).toEqual({
       insideBoundingBox: undefined,
       aroundLatLng: '1,1',
     });
+  });
+
+  it('overrides the aroundLatLng if a defaultPosition parameter is passed', () => {
+    const widget = algoliaPlacesWidget({ defaultPosition: [1, 1] });
+
+    const beforeConfiguration = {
+      aroundLatLng: '12,14',
+    };
+
+    const afterConfiguration = widget.getConfiguration(beforeConfiguration);
+
+    expect(afterConfiguration).toEqual({
+      insideBoundingBox: undefined,
+      aroundLatLng: '1,1',
+    });
+  });
+
+  it('does nothing to aroundLatLng if no defaultPosition parameter is passed', () => {
+    const widget = algoliaPlacesWidget({});
+
+    const beforeConfiguration = {
+      aroundLatLng: '12,14',
+    };
+
+    const afterConfiguration = widget.getConfiguration(beforeConfiguration);
+
+    expect(afterConfiguration).toEqual({});
   });
 
   it('configures aroundLatLng on change event', () => {
@@ -257,7 +283,7 @@ describe('instantsearch widget', () => {
         expect(searchParametersAfter).toBe(searchParametersBefore);
       });
 
-      test('should enforce the default value if no value is in the UI State', () => {
+      test('should not care about the default value even if no value is in the UI State', () => {
         const [widget, helper] = getInitializedWidget();
         // The user presses back (browser), and the URL contains no parameters
         const uiState = {};
@@ -268,7 +294,7 @@ describe('instantsearch widget', () => {
           { uiState }
         );
         expect(searchParametersAfter).toMatchSnapshot();
-        expect(searchParametersAfter.aroundLatLng).toBe('2,2');
+        expect(searchParametersAfter.aroundLatLng).toBe(undefined);
         expect(searchParametersAfter.insideBoundingBox).toBe(undefined);
       });
 

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -4,7 +4,7 @@ import places from '../places.js';
 
 jest.mock('../places.js', () => {
   const module = jest.fn(() => {
-    const instance = { on: jest.fn(), setVal: jest.fn() };
+    const instance = { on: jest.fn(), setVal: jest.fn(), close: jest.fn() };
 
     module.__instance = instance;
     return instance;
@@ -141,8 +141,12 @@ describe('instantsearch widget', () => {
         expect(eventName).toEqual('change');
 
         eventListener({
-          suggestion: { latlng: { lat: '123', lng: '456' }, value: 'Paris' },
+          suggestion: {
+            latlng: { lat: '123', lng: '456' },
+            value: 'Paris',
+          },
         });
+
         expect(helper.search).toBeCalled();
         expect(helper.getState()).toMatchObject({
           insideBoundingBox: undefined,
@@ -197,7 +201,7 @@ describe('instantsearch widget', () => {
         const expectedUiState = {
           places: {
             position: '2,2',
-            query: undefined,
+            query: '',
           },
         };
 
@@ -304,6 +308,22 @@ describe('instantsearch widget', () => {
         expect(searchParametersAfter).toMatchSnapshot();
         expect(searchParametersAfter.insideBoundingBox).toBe(undefined);
         expect(searchParametersAfter.aroundLatLng).toBe('123,123');
+      });
+
+      test('should close the dropdown', () => {
+        const [widget, helper] = getInitializedWidget();
+        // The user presses back (browser), and the URL contains some parameters
+        const uiState = {
+          places: {
+            position: '123,123',
+            query: 'Paris',
+          },
+        };
+
+        const searchParametersBefore = SearchParameters.make(helper.state);
+        widget.getWidgetSearchParameters(searchParametersBefore, { uiState });
+        // Applying a state with new parameters should apply them on the search
+        expect(places.__instance.close).toHaveBeenCalled();
       });
     });
   });

--- a/src/instantsearch/widget.test.js
+++ b/src/instantsearch/widget.test.js
@@ -53,6 +53,20 @@ describe('instantsearch widget', () => {
     });
   });
 
+  it('does not call setQueryParameter during the init step', () => {
+    // Using setQueryParameter to change a filter value during the init step will
+    // have unintented consequences such as resetting the pagination to 0.
+    // We should not do that
+    const client = createFakeClient();
+    const helper = createFakekHelper(client);
+    const widget = algoliaPlacesWidget(defaultOptions);
+
+    helper.setQueryParameter = jest.fn();
+    widget.init({ helper });
+
+    expect(helper.setQueryParameter).not.toHaveBeenCalled();
+  });
+
   it('accepts a defaultPosition parameter', () => {
     const widget = algoliaPlacesWidget({ defaultPosition: [1, 1] });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
The current implementation of the init method of the Places widget makes it so that it resets pagination. This PR fixes this issue by only updating the helper if it was not updated by the routing step.

It also fixes a bug where the places dropdown would open on backward and forward navigation.

**Result**
Demo: [routing demo](https://places-routing.surge.sh/?places%5Bquery%5D=Paris%208e%20Arrondissement%2C%20Paris%2C%20%C3%8Ele-de-France%2C%20France&places%5Bposition%5D=48.8777%2C2.3175&page=6)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
