### PR TITLE
docs: update InstantSearch example

### DIFF
--- a/docs/config.rb
+++ b/docs/config.rb
@@ -78,7 +78,7 @@ configure :build do
   config[:places_autocomplete_dataset_lib_url] = config[:places_autocomplete_dataset_cdn_url]
   config[:places_instantsearch_widget_lib_url] = config[:places_instantsearch_widget_cdn_url]
   config[:instantsearch_lib_url] = 'https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch.min.js'
-  config[:google_maps_lib_url] = 'https://maps.googleapis.com/maps/api/js'
+  config[:google_maps_lib_url] = 'https://maps.googleapis.com/maps/api/js?key=AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ'
   # this may trigger bad behavior, if so, see
   # https://github.com/middleman/middleman-minify-html
   activate :minify_html

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -32,7 +32,7 @@ configure :development do
   config[:places_autocomplete_dataset_lib_url] = 'placesAutocompleteDataset'
   config[:places_instantsearch_widget_lib_url] = 'placesInstantsearchWidget'
   config[:instantsearch_lib_url] = 'https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch.min.js'
-  config[:google_maps_lib_url] = 'https://maps.googleapis.com/maps/api/js'
+  config[:google_maps_lib_url] = 'https://maps.googleapis.com/maps/api/js?key=AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ'
   activate :external_pipeline,
     name: 'places',
     command: 'npm run js:watch -- --output-path docs/.webpack/js',

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -31,8 +31,7 @@ configure :development do
   config[:places_lib_url] = 'places'
   config[:places_autocomplete_dataset_lib_url] = 'placesAutocompleteDataset'
   config[:places_instantsearch_widget_lib_url] = 'placesInstantsearchWidget'
-  config[:instantsearch_lib_url] = 'https://cdn.jsdelivr.net/instantsearch.js/1.6.0/instantsearch.min.js'
-  config[:instantsearch_googlemaps_lib_url] = 'https://cdn.jsdelivr.net/instantsearch-googlemaps/1.2.4/instantsearch-googlemaps.min.js'
+  config[:instantsearch_lib_url] = 'https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch.min.js'
   config[:google_maps_lib_url] = 'https://maps.googleapis.com/maps/api/js'
   activate :external_pipeline,
     name: 'places',
@@ -78,8 +77,7 @@ configure :build do
   config[:places_lib_url] = config[:places_cdn_url]
   config[:places_autocomplete_dataset_lib_url] = config[:places_autocomplete_dataset_cdn_url]
   config[:places_instantsearch_widget_lib_url] = config[:places_instantsearch_widget_cdn_url]
-  config[:instantsearch_lib_url] = 'https://cdn.jsdelivr.net/instantsearch.js/1.6.0/instantsearch.min.js'
-  config[:instantsearch_googlemaps_lib_url] = 'https://cdn.jsdelivr.net/instantsearch-googlemaps/1.2.4/instantsearch-googlemaps.min.js'
+  config[:instantsearch_lib_url] = 'https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch.min.js'
   config[:google_maps_lib_url] = 'https://maps.googleapis.com/maps/api/js'
   # this may trigger bad behavior, if so, see
   # https://github.com/middleman/middleman-minify-html

--- a/docs/source/examples.html.md.erb
+++ b/docs/source/examples.html.md.erb
@@ -2,6 +2,8 @@
 title: Examples
 layout: documentation
 ---
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch-theme-algolia.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1/leaflet.css" />
 <script src="https://cdn.jsdelivr.net/leaflet/1/leaflet.js"></script>
 

--- a/docs/source/partials/examples/_instantsearch.html.erb
+++ b/docs/source/partials/examples/_instantsearch.html.erb
@@ -27,6 +27,13 @@ var searchBox = placesInstantsearchWidget({
 var geosearch = instantsearch.widgets.geoSearch({
   container: '#map-instantsearch-container',
   googleReference: window.google,
+  builtInMarker: {
+    createOptions: function(item) {
+      return {
+        title: item.Brand + ' ' + item.Name
+      };
+    }
+  }
 });
 
 search.addWidget(configure);

--- a/docs/source/partials/examples/_instantsearch.html.erb
+++ b/docs/source/partials/examples/_instantsearch.html.erb
@@ -14,9 +14,10 @@ var search = instantsearch({
   appId: 'latency',
   apiKey: 'ffc36feb6e9df06e1c3c4549b5af2b31',
   indexName: 'starbucks',
-  searchParameters: {
-    hitsPerPage: 50
-  }
+});
+
+var configure = instantsearch.widgets.configure({
+  hitsPerPage: 25,
 });
 
 var searchBox = placesInstantsearchWidget({
@@ -28,6 +29,7 @@ var geosearch = instantsearch.widgets.geoSearch({
   googleReference: window.google,
 });
 
+search.addWidget(configure);
 search.addWidget(searchBox);
 search.addWidget(geosearch);
 search.start();

--- a/docs/source/partials/examples/_instantsearch.html.erb
+++ b/docs/source/partials/examples/_instantsearch.html.erb
@@ -7,7 +7,6 @@
 
 <%= javascript_include_tag config[:instantsearch_lib_url] %>
 <%= javascript_include_tag config[:places_instantsearch_widget_lib_url] %>
-<%= javascript_include_tag config[:instantsearch_googlemaps_lib_url] %>
 <%= javascript_include_tag config[:google_maps_lib_url] %>
 <script>
 (function() {
@@ -24,18 +23,13 @@ var searchBox = placesInstantsearchWidget({
   container: document.querySelector('#input-map-instantsearch')
 });
 
-var map = instantsearchGoogleMaps({
-  container: document.querySelector('#map-instantsearch-container'),
-  prepareMarkerData: ({Brand, Name, 'Street Combined': street}) => {
-    return {
-      title: `${Brand} - ${Name}`
-    };
-  },
-  refineOnMapInteraction: true
+var geosearch = instantsearch.widgets.geoSearch({
+  container: '#map-instantsearch-container',
+  googleReference: window.google,
 });
 
 search.addWidget(searchBox);
-search.addWidget(map);
+search.addWidget(geosearch);
 search.start();
 })();
 </script>


### PR DESCRIPTION
**Summary**

This PR updates the InstantSearch example to use the built-in GeoSearch widget. Note that the examples doesn't work (yet). We should merge the PR #554 before this one. Changes:

- remove the legacy lib script
- update InstantSearch to 2.10.1 (and usage)
- add an API Key for the Google Maps (it removes the overlay)

**Before**

![screen shot 2018-09-17 at 11 30 04](https://user-images.githubusercontent.com/6513513/45615520-0bfafd80-ba6d-11e8-893f-e2a9008f2997.png)

**After**

![screen shot 2018-09-17 at 11 29 49](https://user-images.githubusercontent.com/6513513/45615524-0ef5ee00-ba6d-11e8-9b81-fbeb8fcfba8e.png)