### PR TITLE
doc(copy-examples): fix clipboard selectors and code block style

### DIFF
--- a/docs/source/javascripts/documentation-layout.js
+++ b/docs/source/javascripts/documentation-layout.js
@@ -12,4 +12,4 @@ anchorableElements(
     .querySelector('.documentation-container')
     .querySelectorAll('h2, h3, .api-entry')
 );
-activateClipboard([...document.querySelectorAll('.code')]);
+activateClipboard(document.querySelectorAll('.rouge-code'));

--- a/docs/source/stylesheets/components/_clipboard.scss
+++ b/docs/source/stylesheets/components/_clipboard.scss
@@ -1,10 +1,19 @@
-.code {
+.rouge-code {
   position:relative;
 
   .clipboard {
     position: absolute;
     top: 0;
     right: 0;
+    width: 40px;
+    height: 39px;
+    background-color: #f4f4f4;
+    border: none;
+    display: flex;
+    box-sizing: border-box;
+    border-bottom-left-radius: 4px;
+    justify-content: center;
+    align-items: center;
     opacity: 0;
     transition: opacity 150ms;
   }

--- a/docs/source/stylesheets/components/_code-highlight.scss
+++ b/docs/source/stylesheets/components/_code-highlight.scss
@@ -83,7 +83,7 @@
     width: 100%;
   }
 
-  .code {
+  .rouge-code {
     flex: 1 0 0px;
     margin-left: -1px;
 


### PR DESCRIPTION
**Summary**
This PR fixes a bug where clipboardJS was applied to the wrong selector.
Copy to clipboard is now back on code samples, with _very slightly_ fresher styles.

This makes it a lot easier for our users to reuse our examples.

**Result**
Example on the documentation page:
![image](https://user-images.githubusercontent.com/5136989/47417782-0df56200-d779-11e8-91fd-c7089d5ea9e5.png)

Example on the example page:
![image](https://user-images.githubusercontent.com/5136989/47417836-29606d00-d779-11e8-9e7a-4a3b7666aa38.png)
