### PR TITLE
doc(api-clients): combine rest doc and api clients doc in separate page

### DIFF
--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -1,7 +1,61 @@
 ---
-title: REST API
+title: API Clients and REST API
 layout: documentation
 ---
+
+## Places.js Library
+
+**Important:** The default way to use Places is through the Places.js library.
+
+You can read more about how to use the Places.js library in the [documentation section](documentation.html). The present section is describing alternative ways of accessing Places data. You should first checkout out the [documentation](documentation.html) for Places.js as well as the [examples](examples.html) page to determine whether or not the clients are a better fit for your use case.
+
+## API Clients
+### JavaScript API Client
+
+You can directly query the [Places REST API](api-client.html#rest-api) using our [JavaScript API client](https://github.com/algolia/algoliasearch-client-javascript), either in browsers or with [Node.js](https://nodejs.org/).
+
+
+
+```js
+// var algoliasearch = require('algoliasearch');
+var places = algoliasearch.initPlaces(/*appId, apiKey*/);
+places
+  .search(/*{REST API Params}*/, function(err, res) {
+    if (err) {
+      throw err;
+    }
+    console.log(res);
+  });
+
+places
+  .getObject(/*{REST API Params}*/, function(err, res) {
+    if (err) {
+      throw err;
+    }
+    console.log(res);
+  });
+```
+
+Note: _Like with the Places.js library, you need to provide your Places App credentials in order for the clients to function properly. If you do not have a Places application, you can create one by [signing up for free](https://www.algolia.com/users/sign_up/places)._
+
+### PHP API Client
+
+You can directly query the [Places REST API](api-client.html#rest-api) with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php), so that you can do backend Places searches.
+
+```php
+<?php
+
+$appId = 'YOUR_PLACES_APP_ID';
+$apiKey = 'YOUR_PLACES_API_KEY';
+
+$places = \AlgoliaSearch\Client::initPlaces($appId, $apiKey);
+
+$result = $places->search('Paris');
+var_dump($result);
+```
+
+Note: _Like with the Places.js library, you need to provide your Places App credentials in order for the clients to function properly. If you do not have a Places application, you can create one by [signing up for free](https://www.algolia.com/users/sign_up/places)._
+
 ## REST API
 
 The Algolia Places REST API supports HTTPS and is available via the `https://places-dsn.algolia.net` domain (leveraging our [Distributed Search Network](https://www.algolia.com/dsn) infrastructure).

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -711,6 +711,10 @@ console.log(suggestion.highlight);
   </tbody>
 </table>
 
+## Integrations
+
+On top of the regular **places** component, the places.js library offers additional integrations with autocomplete.js and InstantSearch.js.
+
 ### autocomplete.js
 
 The places.js library is leveraging [Algolia's autocomplete.js](https://github.com/algolia/autocomplete.js) library.
@@ -731,7 +735,7 @@ All the places.js [options](#options) are available and can be passed to the `pl
 
 You will need an [Algolia account](https://www.algolia.com/) to be able to search into your own data. See the [autocomplete.js dataset example](examples.html#autocompletejs).
 
-### instantsearch.js
+### InstantSearch.js
 
 If you're already using instantsearch.js, you can use Algolia Places out of the box. This
 widget will do a search of places using Algolia Places and when an address is selected, it
@@ -775,56 +779,6 @@ This position is an array of two numbers, representing the latitude and the long
     </tr>
     </tbody>
     </table>
-
-### JavaScript API Client
-
-You can directly query the [Places REST API](rest.html) using our [JavaScript API client](https://github.com/algolia/algoliasearch-client-javascript),
-either in browsers or with [Node.js](https://nodejs.org/).
-
-
-
-```js
-// var algoliasearch = require('algoliasearch');
-var places = algoliasearch.initPlaces(/*appId, apiKey*/);
-places
-  .search(/*{REST API Params}*/, function(err, res) {
-    if (err) {
-      throw err;
-    }
-    console.log(res);
-  });
-
-places
-  .getObject(/*{REST API Params}*/, function(err, res) {
-    if (err) {
-      throw err;
-    }
-    console.log(res);
-  });
-```
-
-### PHP API Client
-
-You can directly query the [Places REST API](rest.html) with our [PHP API Client](https://github.com/algolia/algoliasearch-client-php),
-so that you can do backend Places searches.
-
-Create a [Places account](https://www.algolia.com/users/sign_up/places) to get your credentials.
-
-```php
-<?php
-
-$appId = 'YOUR_PLACES_APP_ID';
-$apiKey = 'YOUR_PLACES_API_KEY';
-
-$places = \AlgoliaSearch\Client::initPlaces($appId, $apiKey);
-
-$result = $places->search('Paris');
-var_dump($result);
-```
-
-### REST API
-
-Behind the places.js JavaScript library lies a complete REST API. Read the underlying [REST API documentation](rest.html).
 
 ## Security
 The default way of using Places is to pass your Places application ID and API Key to the Places library.

--- a/docs/source/index.html.haml
+++ b/docs/source/index.html.haml
@@ -88,7 +88,7 @@ layout: landing
           .content.m-l-r-auto
             %h3.text-bg Link suggestions to a map
             %p Visualize the results at a glance by displaying them on a real-time map.
-            = link_to("View code", "examples.html#link-to-a-map")
+            = link_to("View code", "examples.html#displaying-on-a-map")
       .spacer32
 
       .flex-container.flex-align-center.reverse-col
@@ -96,7 +96,7 @@ layout: landing
           .content.m-l-r-auto
             %h3.text-bg autocomplete.js & instantsearch.js ready
             %p Build unique search experiences with the autocomplete.js & instantsearch.js plugins for Algolia Places.
-            = link_to("View code", "examples.html#autocompletejs")
+            = link_to("View code", "examples.html#places--custom-data")
         .flex-it-2
           = image_tag("images/hp-demo-autocompletejs.gif", class: "gif p-large radius6 elevation0 fill-white w100p z-100 pos-rel")
       .spacer32

--- a/docs/source/partials/navigation.html.haml
+++ b/docs/source/partials/navigation.html.haml
@@ -25,10 +25,12 @@
       %ul.ac-nav-menu-list
         %li.ac-nav-menu-list-item{nav_active("documentation.html")}
           %a{href: "documentation.html", title: "Documentation", :data => {:path => "documentation.html"}} Documentation
-        %li.ac-nav-menu-list-item{nav_active("pricing.html")}
-          %a{href: "pricing.html", title: "Pricing", :data => {:path => "pricing.html"}} Pricing
+        %li.ac-nav-menu-list-item{nav_active("api-clients.html")}
+          %a{href: "api-clients.html", title: "API Clients", :data => {:path => "api-clients.html"}} API Clients
         %li.ac-nav-menu-list-item{nav_active("examples.html")}
           %a{href: "examples.html", title: "Examples", :data => {:path => "examples.html"}} Examples
+        %li.ac-nav-menu-list-item{nav_active("pricing.html")}
+          %a{href: "pricing.html", title: "Pricing", :data => {:path => "pricing.html"}} Pricing
         %li.ac-nav-menu-list-item{nav_active("support.html")}
           %a{href: "support.html", title: "Support", :data => {:path => "support.html"}} Support
         %li.ac-nav-menu-list-item{nav_active("contact.html")}

--- a/docs/source/stylesheets/components/_documentation.scss
+++ b/docs/source/stylesheets/components/_documentation.scss
@@ -27,7 +27,7 @@
       position: relative;
 
       li {
-        height: 26px;
+        height: inherit;
         line-height: 26px;
 
         &:before {


### PR DESCRIPTION
**Summary**

Moves the API Clients documentation together with the Rest API documentation and exposes the page in the nav bar.

Moves the autocomplete.js and IS.js subsections of Usage into an Integrations sections in the main documentation page.

**Result**
- API Clients page

![image](https://user-images.githubusercontent.com/5136989/47502539-5fc8e580-d868-11e8-8fe2-752ae06be4e9.png)

- Integrations section in Documentation

![image](https://user-images.githubusercontent.com/5136989/47502578-7bcc8700-d868-11e8-9a09-0b4101e90eb9.png)

