### PR TITLE
feat(postcodes): expose postcodes array in suggestions

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -657,12 +657,27 @@ Latitude and longitude of the place found. Shape: `{lat: 48.797885, lng: 2.33703
 Type: **string**
 </td>
 <td markdown="1">
-Postcode (or ZIP Code) of the place found.
+The best matching postcode (or ZIP Code) of the place found.
 
 Examples:
 
- - 94230
- - 1001
+ - 94104
+ - 75009
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
+<div class="api-entry" id="api-suggestion-postcodes"><code>postcodes</code></div>
+
+Type: **array**
+</td>
+<td markdown="1">
+The list of all postcode (or ZIP Code) of the place found.
+
+Examples:
+
+ - `["94102","94103","94104",...]`
+ - `["75008", "75009"]`
 </td>
     </tr>
     <tr>
@@ -690,8 +705,11 @@ Type: **object**
 Given the query, contains the highlighted values of the following attributes:
 
 - name
-- administrative
+- suburb
 - city
+- postcode
+- county
+- administrative
 - country
 
 Example:

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -676,7 +676,7 @@ The list of all postcode (or ZIP Code) of the place found.
 
 Examples:
 
- - `["94102","94103","94104",...]`
+ - `["94102", "94103", "94104", ... ]`
  - `["75008", "75009"]`
 </td>
     </tr>

--- a/docs/source/javascripts/index.js
+++ b/docs/source/javascripts/index.js
@@ -49,6 +49,13 @@ const $response = document.querySelector('#json-response');
 const $responseText = document.querySelector('#json-response-text');
 const $responseTiming = document.querySelector('#json-response-timing');
 placesAutocomplete.on('change', e => {
+  let postcodes = (e.suggestion.postcodes || []).slice(0, 3);
+  if (postcodes.length !== (e.suggestion.postcodes || []).length) {
+    postcodes = [...postcodes, '...'];
+  } else if (postcodes.length === 0) {
+    postcodes = undefined;
+  }
+
   const content = {
     ...e,
     // hide advanced API event data in demo
@@ -58,6 +65,7 @@ placesAutocomplete.on('change', e => {
       hitIndex: undefined,
       query: undefined,
       rawAnswer: undefined,
+      postcodes,
     },
     rawAnswer: undefined,
     suggestionIndex: undefined,

--- a/src/formatHit.test.js
+++ b/src/formatHit.test.js
@@ -184,6 +184,57 @@ describe('formatHit', () => {
         highlight: { country: undefined },
       },
     }),
+    getTestCase({
+      name: 'no postcode',
+      hit: { postcode: undefined },
+      expected: {
+        postcode: undefined,
+        postcodes: undefined,
+        highlight: { postcode: undefined },
+      },
+    }),
+    getTestCase({
+      name: 'postcode[0] matches',
+      hit: {
+        postcode: ['75009', '75010'],
+        _highlightResult: {
+          postcode: [
+            {
+              value: '<em>75009</em>',
+              matchedWords: ['75009'],
+              matchLevel: 'full',
+            },
+            { value: '75010', matchedWords: [], matchLevel: 'none' },
+          ],
+        },
+      },
+      expected: {
+        postcode: '75009',
+        postcodes: ['75009', '75010'],
+        highlight: { postcode: '<em>75009</em>' },
+      },
+    }),
+    getTestCase({
+      name: 'postcode[1] matches',
+      hit: {
+        postcode: ['75009', '75010'],
+        _highlightResult: {
+          postcode: [
+            { value: '75009', matchedWords: [], matchLevel: 'none' },
+            {
+              value: '<em>75010</em>',
+              matchedWords: ['75010'],
+              matchLevel: 'full',
+            },
+          ],
+        },
+      },
+      expected: {
+        postcode: '75010',
+        postcodes: ['75009', '75010'],
+        highlight: { postcode: '<em>75010</em>' },
+      },
+    }),
   ];
 
   testCases.forEach(testCase =>
@@ -220,6 +271,7 @@ describe('formatHit', () => {
         type: output.type,
         latlng: output.latlng,
         postcode: output.postcode,
+        postcodes: output.postcodes,
       });
 
       expect(output.rawAnswer).toEqual('rawAnswer');
@@ -258,6 +310,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
       county: [{ value: 'County of Paris' }],
       administrative: [{ value: 'Île-de-France' }],
       country: { value: 'France' },
+      postcode: [{ value: '75004' }],
     },
   };
 
@@ -272,6 +325,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
       lng: '456',
     },
     postcode: '75004',
+    postcodes: ['75004'],
     hitIndex: 0,
     query: 'query',
     rawAnswer: 'rawAnswer',
@@ -281,6 +335,7 @@ function getTestCase({ name, hit: userHit = {}, expected: userExpected = {} }) {
       administrative: 'Île-de-France',
       country: 'France',
       county: 'County of Paris',
+      postcode: '75004',
     },
   };
 


### PR DESCRIPTION
**Summary**

This PR exposes the postcodes array in the suggestion object.
It now also returns the best matching postcode as `postcode` when possible.
the postcode field is now also included in the highlight object.

**Result**
- exposes the postcodes field
- updates tests to include postcodes array
- updates the documentation to include section about postcodes
![image](https://user-images.githubusercontent.com/5136989/47659026-54d9c200-db94-11e8-8711-b2e57b18b1b8.png)

- update landing formatting with new postcodes object (truncated for readability)

![image](https://user-images.githubusercontent.com/5136989/47658856-09bfaf00-db94-11e8-8d82-b174e87b11a4.png)
