### PR TITLE
doc(mobile-clients): add documentation about usage of Places in mobile clients

### DIFF
--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -18,7 +18,7 @@ You can directly query the [Places REST API](api-client.html#rest-api) using our
 
 ```js
 // var algoliasearch = require('algoliasearch');
-var places = algoliasearch.initPlaces(/*appId, apiKey*/);
+var places = algoliasearch.initPlaces('YOUR_PLACES_APP_ID', 'YOUR_PLACES_API_KEY');
 places
   .search(/*{REST API Params}*/, function(err, res) {
     if (err) {
@@ -62,7 +62,7 @@ You can directly query the [Places REST API](api-client.html#rest-api) with our 
 
 ```swift
 // initialize client
-let places = PlacesClient(appID: appID, apiKey: apiKey)
+let places = PlacesClient(appID: 'YOUR_PLACES_APP_ID', apiKey: 'YOUR_PLACES_API_KEY')
 
 // craft a query
 let query = PlacesQuery()
@@ -88,7 +88,7 @@ You can directly query the [Places REST API](api-client.html#rest-api) with our 
 
 ```java
 // initialize client
-PlacesClient places = new PlacesClient(PLACES_APP_ID, PLACES_API_KEY);
+PlacesClient places = new PlacesClient('YOUR_PLACES_APP_ID', 'YOUR_PLACES_API_KEY');
 
 // craft a query
 PlacesQuery query = new PlacesQuery();

--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -62,7 +62,7 @@ You can directly query the [Places REST API](api-client.html#rest-api) with our 
 
 ```swift
 // initialize client
-let places = PlacesClient(appID: 'YOUR_PLACES_APP_ID', apiKey: 'YOUR_PLACES_API_KEY')
+let places = PlacesClient(appID: "YOUR_PLACES_APP_ID", apiKey: "YOUR_PLACES_API_KEY")
 
 // craft a query
 let query = PlacesQuery()
@@ -88,7 +88,7 @@ You can directly query the [Places REST API](api-client.html#rest-api) with our 
 
 ```java
 // initialize client
-PlacesClient places = new PlacesClient('YOUR_PLACES_APP_ID', 'YOUR_PLACES_API_KEY');
+PlacesClient places = new PlacesClient("YOUR_PLACES_APP_ID", "YOUR_PLACES_API_KEY");
 
 // craft a query
 PlacesQuery query = new PlacesQuery();

--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -56,6 +56,56 @@ var_dump($result);
 
 Note: _Like with the Places.js library, you need to provide your Places App credentials in order for the clients to function properly. If you do not have a Places application, you can create one by [signing up for free](https://www.algolia.com/users/sign_up/places)._
 
+### Swift API Client
+
+You can directly query the [Places REST API](api-client.html#rest-api) with our [Swift API Client](https://github.com/algolia/algoliasearch-client-swift), so that you can do backend Places searches.
+
+```swift
+// initialize client
+let places = PlacesClient(appID: appID, apiKey: apiKey)
+
+// craft a query
+let query = PlacesQuery()
+query.query = "Paris"
+query.type = .city
+query.hitsPerPage = 10
+query.aroundLatLngViaIP = false
+query.aroundLatLng = LatLng(lat: 32.7767, lng: -96.7970) // Dallas, TX, USA
+query.language = "en"
+query.countries = ["fr", "us"]
+
+// search
+places.search(query) { (content, error) in
+    // content?["hits"] to access the hits
+}
+```
+
+Note: _Like with the Places.js library, you need to provide your Places App credentials in order for the clients to function properly. If you do not have a Places application, you can create one by [signing up for free](https://www.algolia.com/users/sign_up/places)._
+
+### Android API Client
+
+You can directly query the [Places REST API](api-client.html#rest-api) with our [Android API Client](https://github.com/algolia/algoliasearch-client-android), so that you can do backend Places searches.
+
+```java
+// initialize client
+PlacesClient places = new PlacesClient(PLACES_APP_ID, PLACES_API_KEY);
+
+// craft a query
+PlacesQuery query = new PlacesQuery();
+query.setQuery("Paris");
+query.setType(PlacesQuery.Type.CITY);
+query.setHitsPerPage(10);
+query.setAroundLatLngViaIP(false);
+query.setAroundLatLng(new PlacesQuery.LatLng(32.7767, -96.7970)); // Dallas, TX, USA
+query.setLanguage("en");
+query.setCountries("fr", "us");
+
+// search
+places.searchAsync(query, new CompletionHandler() {
+    ...
+});
+```
+
 ## REST API
 
 The Algolia Places REST API supports HTTPS and is available via the `https://places-dsn.algolia.net` domain (leveraging our [Distributed Search Network](https://www.algolia.com/dsn) infrastructure).

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -23,8 +23,8 @@ Here's a small example using it:
 <%= javascript_include_tag config[:places_cdn_url] %>
 <script>
   var placesAutocomplete = places({
-    appId: <YOUR_PLACES_APP_ID>,
-    apiKey: <YOUR_PLACES_API_KEY>,
+    appId: 'YOUR_PLACES_APP_ID',
+    apiKey: 'YOUR_PLACES_API_KEY',
     container: document.querySelector('#address-input')
   });
 </script>
@@ -56,8 +56,8 @@ Initialize the places.js library:
 ```js
 var places = require('places.js');
 var placesAutocomplete = places({
-  appId: <YOUR_PLACES_APP_ID>,
-  apiKey: <YOUR_PLACES_API_KEY>,
+  appId: 'YOUR_PLACES_APP_ID',
+  apiKey: 'YOUR_PLACES_API_KEY',
   container: document.querySelector('#address-input')
 });
 ```
@@ -74,8 +74,8 @@ To turn any HTML `<input />` into an address search bar make sure you include th
 
 ```js
 var options = {
-  appId: <YOUR_PLACES_APP_ID>,
-  apiKey: <YOUR_PLACES_API_KEY>,
+  appId: 'YOUR_PLACES_APP_ID',
+  apiKey: 'YOUR_PLACES_API_KEY',
   container: '#my-input-DOM-selector',
   // ...
 };
@@ -86,8 +86,8 @@ Advanced example using all parameters:
 
 ```js
 var options = {
-  appId: <YOUR_PLACES_APP_ID>,
-  apiKey: <YOUR_PLACES_API_KEY>,
+  appId: 'YOUR_PLACES_APP_ID',
+  apiKey: 'YOUR_PLACES_API_KEY',
   container: document.querySelector('#demo'),
   language: 'de', // Receives results in German
   countries: ['us', 'ru'], // Search in the United States of America and in the Russian Federation
@@ -345,8 +345,8 @@ The Algolia Places autocomplete exposes some events that you can register to:
 
 ```js
 var placesAutocomplete = places({
-  appId: <YOUR_PLACES_APP_ID>,
-  apiKey: <YOUR_PLACES_API_KEY>,
+  appId: 'YOUR_PLACES_APP_ID',
+  apiKey: 'YOUR_PLACES_API_KEY',
   container: document.querySelector('#demo')
 });
 


### PR DESCRIPTION
**Summary**

- Adds documentation about Places in the mobile clients
- Makes the clients use the pulled credentials
- Fixes the credentials in the documentation page

**Result**
Swift
![image](https://user-images.githubusercontent.com/5136989/47723389-b497a200-dc54-11e8-92e6-b66e0c47658e.png)

Android
![image](https://user-images.githubusercontent.com/5136989/47723424-c8430880-dc54-11e8-8abc-23771b8f2b7b.png)

Documentation
![image](https://user-images.githubusercontent.com/5136989/47723513-f3c5f300-dc54-11e8-81ca-5b414ea49305.png)

The credentials were manually shortened for security reasons