### PR TITLE
fix(caching): disable autocomplete caching

### DIFF
--- a/src/createAutocompleteDataset.js
+++ b/src/createAutocompleteDataset.js
@@ -18,5 +18,6 @@ export default function createAutocompleteDataset(options) {
     templates,
     displayKey: 'value',
     name: 'places',
+    cache: false,
   };
 }

--- a/src/createAutocompleteDataset.test.js
+++ b/src/createAutocompleteDataset.test.js
@@ -21,6 +21,7 @@ describe('createAutocompleteDataset', () => {
       templates: { template: 'test', value: 'test', option: 'test' },
       displayKey: 'value',
       name: 'places',
+      cache: false,
     });
   });
 


### PR DESCRIPTION
**Summary**
The autocomplete instance was caching the first letter query, and does not check for changes in the parameters. This behaviour was buggy and led to having the instance return the same results for single letter queries regardless of configuration change.

E.g: `L` with `type: 'city'` will be cached (returns Toulouse) and changing the type to `country` and typing `L` will return again `Toulouse`.

The JS client already does caching of previous queries so there is no point in having that cache that introduces bugs.