### PR TITLE
doc(fix-broken-links): prepare documentation for Algolia doc refresh

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -323,7 +323,7 @@ given the area density.
 Type: **string**
 </td>
 <td markdown="1">
-Filters the results inside the area defined by the two extreme points of a rectangle. [See guide](https://www.algolia.com/doc/guides/geo-search/geo-search-overview/#insideboundingbox).
+Filters the results inside the area defined by the two extreme points of a rectangle. [See guide](https://www.algolia.com/doc/guides/managing-results/refine-results/geolocation/#filter-inside-rectanglepolygonal-area) or [API reference](https://www.algolia.com/doc/api-reference/api-parameters/insideBoundingBox/).
 
 Format: `topRightLat, topRightLng, bottomLeftLat, bottomLeftLng`
 
@@ -337,7 +337,7 @@ Example: `"60, 16, 40, -4"`
 Type: **string**
 </td>
 <td markdown="1">
-Filters the results inside the area defined by a shape. [See guide](https://www.algolia.com/doc/guides/geo-search/geo-search-overview/#insidepolygon).
+Filters the results inside the area defined by a shape. [See guide](https://www.algolia.com/doc/guides/managing-results/refine-results/geolocation/#filter-inside-rectanglepolygonal-area) or [API reference](https://www.algolia.com/doc/api-reference/api-parameters/insidePolygon/).
 
 Format: `p1Lat, p1Lng, p2Lat, p2Lng, p3Lat, p3Lng...`
 </td>
@@ -905,7 +905,7 @@ If you want to have strong control on who accesses Places with your API Key, you
 
 For instance, for Places, you can create short-lived API Keys for every single user based on your own metrics, using secured API Keys.
 
-There is a great tutorial on [how to use secured API Keys](https://www.algolia.com/doc/tutorials/security/api-keys/secured-api-keys/how-to-restrict-the-search-to-a-subset-of-records-belonging-to-a-specific-user/#introduction) in the official documentation of Algolia.
+There is a great tutorial on [how to use secured API Keys](https://www.algolia.com/doc/guides/security/api-keys/how-to/how-to-restrict-the-search-to-a-subset-of-records-belonging-to-a-specific-user/#introduction) in the official documentation of Algolia.
 
 ## Styling
 

--- a/docs/source/index.html.haml
+++ b/docs/source/index.html.haml
@@ -149,7 +149,7 @@ layout: landing
               Native support of
               %b typing mistakes
               thanks to the
-              = link_to("unique way", "https://www.algolia.com/doc/relevance/typo-tolerance")
+              = link_to("unique way", "https://www.algolia.com/doc/guides/managing-results/optimize-search-results/typo-tolerance/")
               Algolia handles typos and ranks results accordingly.
 
       .flex-it-2.flex-container.flex-dir-col


### PR DESCRIPTION
**Summary**
This PR updates links to point to the new location of some of the documentation content in Algolia Doc after the refresh.

This PR is **low priority** because **no link was broken** with the refresh of the documentation, although some of the current hashes will be incorrect and therefore we will not always direct the visitor to the exact content we were pointing to before.

**Result**
- Fixes 1 already broken link (link to current doc returns 404)
- Improves the links' hashes to point the exact same content as before (or the closest reworked content)

**Methodology**
I grep'ed the documentation looking for the pattern `algolia.com/doc`, and checked every link. If we have any links to the documentation that does not match this pattern, I will have missed them.

I looked for `instantsearch` and `autocomplete` links, in case we had links pointing to the documentation of these projects since it was moved to the main documentation.

I also very quickly checked for `algolia.com` links to see if I missed anything.

**DO NOT MERGE UNTIL RELEASE OF THE DOCUMENTATION REFRESH**