### PR TITLE
fix(babel-node): make @babel/polyfill a main dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@babel/plugin-proposal-throw-expressions": "7.2.0",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
     "@babel/plugin-syntax-import-meta": "7.2.0",
-    "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "7.2.3",
     "algoliasearch-helper": "2.26.1",
     "babel-core": "7.0.0-bridge.0",
@@ -72,6 +71,7 @@
     "webpack-cli": "3.2.1"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "algolia-aerial": "^1.5.3",
     "algoliasearch": "^3.31.0",
     "autocomplete.js": "^0.35.0",


### PR DESCRIPTION
**Summary**
This PR makes `@babel/polyfill` a main dependency, as the previous fix still failed in some cases.

**Result**
Hopefully, the library is now properly compiled.