### PR TITLE
fix(promise-polyfill): remove babel-polyfill and let babel do magic

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,5 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "targets": "> 0.25%, not dead",
-        "useBuiltIns": "usage"
-      }
-    ]
-  ],
+  "presets": ["@babel/preset-env"],
   "env": {
     "npm": {
       "plugins": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "webpack-cli": "3.2.1"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
     "algolia-aerial": "^1.5.3",
     "algoliasearch": "^3.31.0",
     "autocomplete.js": "^0.35.0",

--- a/src/configure/index.js
+++ b/src/configure/index.js
@@ -33,12 +33,13 @@ const extractParams = ({
     extracted.aroundLatLngViaIP = aroundLatLngViaIP;
   }
 
-  return Object.assign(extracted, {
+  return {
+    ...extracted,
     aroundRadius,
     insideBoundingBox,
     insidePolygon,
     getRankingInfo,
-  });
+  };
 };
 
 const extractControls = ({

--- a/src/createAutocompleteSource.js
+++ b/src/createAutocompleteSource.js
@@ -61,12 +61,14 @@ export default function createAutocompleteSource({
   }
 
   function searcher(query, cb) {
-    const searchParams = Object.assign(
-      {},
-      params,
-      userCoords && { aroundLatLng: userCoords },
-      { query }
-    );
+    const searchParams = {
+      ...params,
+      query,
+    };
+
+    if (userCoords) {
+      searchParams.aroundLatLng = userCoords;
+    }
 
     return placesClient
       .search(controls.computeQueryParams(searchParams))

--- a/src/instantsearch/widget.js
+++ b/src/instantsearch/widget.js
@@ -109,7 +109,7 @@ class AlgoliaPlacesWidget {
     }
 
     if (searchParameters.aroundLatLng === undefined && !this.query) {
-      const newUiState = Object.assign({}, uiState);
+      const newUiState = { ...uiState };
       delete newUiState.places;
       return newUiState;
     }

--- a/src/places.js
+++ b/src/places.js
@@ -183,7 +183,7 @@ export default function places(options) {
   placesInstance.autocomplete = autocompleteInstance;
 
   placesInstance.configure = configuration => {
-    const safeConfig = Object.assign({}, configuration);
+    const safeConfig = { ...configuration };
 
     delete safeConfig.onHits;
     delete safeConfig.onError;

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,7 +648,7 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
-"@babel/polyfill@^7.0.0", "@babel/polyfill@^7.2.5":
+"@babel/polyfill@^7.0.0":
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.2.5.tgz#6c54b964f71ad27edddc567d065e57e87ed7fa7d"
   integrity sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==


### PR DESCRIPTION
**Summary**
The polyfills we introduced to support IE11 created an issue with the usage of `Promise.finally` due to a bug in the way Babel checks for the polyfill usage: https://github.com/babel/babel/issues/8297#issuecomment-403673151

This PR removes `@babel/polyfill` and uses an alternative syntax for Object.assign that is automatically polyfilled by babel #magic

**Result**
Search works and .finally works in Firefox and in IE11

![image](https://user-images.githubusercontent.com/5136989/52262369-91a01c80-292c-11e9-941e-2f89e8774090.png)

![image](https://user-images.githubusercontent.com/5136989/52262451-cdd37d00-292c-11e9-8a39-ba2e0fb9eca8.png)

