### PR TITLE
fix(empty-postcode-list): fix a bug where an empty postcode list would crash display

### DIFF
--- a/src/formatHit.js
+++ b/src/formatHit.js
@@ -86,9 +86,10 @@ export default function formatHit({
     const county =
       hit.county && hit.county[0] !== name ? hit.county[0] : undefined;
 
-    const { postcode, highlightedPostcode } = hit.postcode
-      ? getBestPostcode(hit.postcode, hit._highlightResult.postcode)
-      : { postcode: undefined, highlightedPostcode: undefined };
+    const { postcode, highlightedPostcode } =
+      hit.postcode && hit.postcode.length
+        ? getBestPostcode(hit.postcode, hit._highlightResult.postcode)
+        : { postcode: undefined, highlightedPostcode: undefined };
 
     const highlight = {
       name: getBestHighlightedForm(hit._highlightResult.locale_names),
@@ -122,7 +123,7 @@ export default function formatHit({
         lng: hit._geoloc.lng,
       },
       postcode,
-      postcodes: hit.postcode ? hit.postcode : undefined,
+      postcodes: hit.postcode && hit.postcode.length ? hit.postcode : undefined,
     };
 
     // this is the value to put inside the <input value=

--- a/src/formatHit.test.js
+++ b/src/formatHit.test.js
@@ -194,6 +194,15 @@ describe('formatHit', () => {
       },
     }),
     getTestCase({
+      name: 'empty postcode list',
+      hit: { postcode: [] },
+      expected: {
+        postcode: undefined,
+        postcodes: undefined,
+        highlight: { postcode: undefined },
+      },
+    }),
+    getTestCase({
       name: 'postcode[0] matches',
       hit: {
         postcode: ['75009', '75010'],


### PR DESCRIPTION
closes #750 

**Summary**
It seems that some records return an empty list of postcodes instead of returning no postcode field at all. This caused issue because we assumed that if the `postcode` field was present, then the `_highlightResult` would also be present, which is not true for empty lists.

This PR fixes that by checking for the empty list.