### PR TITLE
fix(set-val-icon): show correct icon when calling setVal

### DIFF
--- a/autocompleteDataset.js
+++ b/autocompleteDataset.js
@@ -6,7 +6,7 @@
 require('./src/navigatorLanguage');
 const createAutocompleteDataset = require('./src/createAutocompleteDataset')
   .default;
-const css = require('./src/places.css');
+const css = require('./src/places.css').default;
 const insertCss = require('insert-css');
 insertCss(css, { prepend: true });
 

--- a/src/places.js
+++ b/src/places.js
@@ -177,6 +177,13 @@ export default function places(options) {
 
   placesInstance.setVal = (...args) => {
     previousQuery = args[0];
+    if (previousQuery === '') {
+      pin.style.display = '';
+      clear.style.display = 'none';
+    } else {
+      clear.style.display = '';
+      pin.style.display = 'none';
+    }
     autocompleteInstance.autocomplete.setVal(...args);
   };
 


### PR DESCRIPTION
closes #663 

**Fixes**
- **fix(set-val-icon)**: shows clear icon when calling setVal with non-empty string and pin icon when calling with empty string.
- **fix(raw-loader)**: createAutoCompleteDataset now uses es6 module syntax for css.

