### PR TITLE
chore(broken-link): fix link to logo with link to branding page

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -1019,7 +1019,7 @@ You can display Algolia Places results on any map provider.
 
 In accordance with our [terms of use](https://www.algolia.com/policies/terms), you are required to comply with our [Acceptable Use Policy](https://www.algolia.com/policies/acceptable-use).
 
-If your application uses [places.js](https://github.com/algolia/places) library, then the Algolia logo must be included and not altered. If your application uses the Places API directly or any other API client, you must show a "Search by Algolia" logo next to the data. You can find the logo in [SVG format here](https://www.algolia.com/static_assets/images/v3/shared/logos/algolia/search-by-algolia-light-background-8762ce8b.svg).
+If your application uses [places.js](https://github.com/algolia/places) library, then the Algolia logo must be included and not altered. If your application uses the Places API directly or any other API client, you must show a "Search by Algolia" logo next to the data. You can find the logo in [SVG format here](https://www.algolia.com/press/?section=brand-guidelines).
 
 The places.js [is licensed](https://github.com/algolia/places/blob/master/LICENSE) under [MIT](https://en.wikipedia.org/wiki/MIT_License).
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Fixes a broken link that appeared with the redesign of the website. Now points the brand guidelines page.
