### PR TITLE
fix(autocomplete-css): use babel transpiling for places.css

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@ dist/
 docs/build/
 docs/vendor/
 test/npm-lib/
+test/npm-autocomplete/
+test/npm-widget/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/.webpack/
 .coverage/
 .vscode/
 test/npm-lib/places.js
+test/npm-widget/places.js
+test/npm-autocomplete/places.js

--- a/autocompleteDataset.js
+++ b/autocompleteDataset.js
@@ -6,7 +6,7 @@
 require('./src/navigatorLanguage');
 const createAutocompleteDataset = require('./src/createAutocompleteDataset')
   .default;
-const css = require('./src/places.css').default;
+import css from './src/places.css';
 const insertCss = require('insert-css');
 insertCss(css, { prepend: true });
 

--- a/autocompleteDataset.js
+++ b/autocompleteDataset.js
@@ -6,7 +6,7 @@
 require('./src/navigatorLanguage');
 const createAutocompleteDataset = require('./src/createAutocompleteDataset')
   .default;
-import css from './src/places.css';
+const css = require('./babel-css').default;
 const insertCss = require('insert-css');
 insertCss(css, { prepend: true });
 

--- a/babel-css.js
+++ b/babel-css.js
@@ -1,0 +1,5 @@
+// this is proxy file so that babel inlines src/places.css into the css variable
+// since it is not a commonjs file
+import css from './src/places.css';
+
+export default css;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,6 +45,7 @@ done
 # The goal is for the user to be able to require/import places without
 # having to import a complete build (dist/cdn), to avoid duplication of dependencies
 BABEL_DISABLE_CACHE=1 BABEL_ENV=npm babel index.js -o "$dist_dir/index.js"
+BABEL_DISABLE_CACHE=1 BABEL_ENV=npm babel babel-css.js -o "$dist_dir/babel-css.js"
 BABEL_DISABLE_CACHE=1 BABEL_ENV=npm babel autocompleteDataset.js -o "$dist_dir/autocompleteDataset.js"
 BABEL_DISABLE_CACHE=1 BABEL_ENV=npm babel instantsearchWidget.js -o "$dist_dir/instantsearchWidget.js"
 BABEL_DISABLE_CACHE=1 BABEL_ENV=npm babel src/ --out-dir "$dist_dir/src/" --ignore "src/**/*.test.js","src/**/__mocks__/*","src/**/__snapshots__/*"

--- a/test/cdn-autocomplete/index.html
+++ b/test/cdn-autocomplete/index.html
@@ -5,7 +5,7 @@
       .algolia-autocomplete {
         width: 100%;
       }
-      .ad-example-dropdown-menu {
+      .ap-dropdown-menu {
         width: 100%;
         color: black;
         background-color: #fff;
@@ -15,28 +15,28 @@
         padding: .5em;
         box-shadow: 1px 1px 32px -10px rgba(0,0,0,0.62);
       }
-      .ad-example-dropdown-menu .ad-example-suggestion {
+      .ap-dropdown-menu .ap-suggestion {
         cursor: pointer;
         padding: 5px 4px;
       }
-      .ad-example-dropdown-menu .ad-example-suggestion img {
+      .ap-dropdown-menu .ap-suggestion img {
         height: 2em;
         margin-top: .5em;
         margin-right: 10px;
         float: left;
       }
-      .ad-example-dropdown-menu .ad-example-suggestion small {
+      .ap-dropdown-menu .ap-suggestion small {
         font-size: .8em;
         color: #bbb;
       }
-      .ad-example-dropdown-menu .ad-example-suggestion.ad-example-cursor {
+      .ap-dropdown-menu .ap-suggestion.ap-cursor {
         background-color: #B2D7FF;
       }
-      .ad-example-dropdown-menu .ad-example-suggestion em {
+      .ap-dropdown-menu .ap-suggestion em {
         font-weight: bold;
         font-style: normal;
       }
-      .ad-example-header {
+      .ap-header {
         font-weight: bold;
         padding: .5em 0;
         margin-bottom: 1em;
@@ -88,7 +88,7 @@
         hint: false,
         debug: true,
         cssClasses: {
-          prefix: 'ad-example'
+          prefix: 'ap'
         }
       }, [
         rentalsDataset,

--- a/test/npm-autocomplete/import.js
+++ b/test/npm-autocomplete/import.js
@@ -1,0 +1,3 @@
+const placesAutocompleteDataset = require('../../dist/autocompleteDataset');
+
+module.exports = { placesAutocompleteDataset };

--- a/test/npm-autocomplete/index.html
+++ b/test/npm-autocomplete/index.html
@@ -48,7 +48,7 @@
     <input type="search" id="search-box" class="form-control" placeholder="Where are we going?" />
     <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearchLite.min.js"></script>
     <script src="https://cdn.jsdelivr.net/autocomplete.js/0/autocomplete.js"></script>
-    <script type="text/javascript" src="../../dist/cdn/placesAutocompleteDataset.min.js"></script>
+    <script type="text/javascript" src="./places.js"></script>
     <script>
       const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
       const index = client.initIndex('airbnb');

--- a/test/npm-widget/import.js
+++ b/test/npm-widget/import.js
@@ -1,0 +1,3 @@
+const placesInstantsearchWidget = require('../../dist/instantsearchWidget');
+
+module.exports = { placesInstantsearchWidget };

--- a/test/npm-widget/index.html
+++ b/test/npm-widget/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+
+  </head>
+  <body>
+    <input type="search" id="search-box" class="form-control" placeholder="Where are you looking for a coffee?" />
+    
+    <script src="https://cdn.jsdelivr.net/instantsearch.js/2.10.1/instantsearch.min.js"></script>
+    <script type="text/javascript" src="./places.js"></script>
+    <script>
+      window.instantsearchInstance = instantsearch({
+        appId: 'latency',
+        apiKey: 'ffc36feb6e9df06e1c3c4549b5af2b31',
+        indexName: 'starbucks',
+      });
+      
+      const configure = instantsearch.widgets.configure({
+        hitsPerPage: 25,
+      });
+      
+      const searchBox = placesInstantsearchWidget({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
+        container: document.querySelector('#search-box')
+      });
+      
+      window.instantsearchInstance.addWidget(configure);
+      window.instantsearchInstance.addWidget(searchBox);
+      window.instantsearchInstance.start();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #886 

**Summary**
Uses babel transpiler to inliine the css into the autocomplete file.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
```
npm run build
less dist/autocomplete.js # <- should have a css variable instead of a require
```
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

I am on vacation, so I'll let you release.