### PR TITLE
fix(rate-limit-ci): Use authenticated places app in E2E tests

### DIFF
--- a/src/places.css
+++ b/src/places.css
@@ -83,7 +83,7 @@
 }
 
 .ap-input-icon.ap-icon-pin {
-  cursor: initial;
+  cursor: pointer;
 }
 
 .ap-input-icon svg {

--- a/test/cdn-autocomplete-min/index.html
+++ b/test/cdn-autocomplete-min/index.html
@@ -74,6 +74,8 @@
       // we automatically inject the default CSS
       // all the places.js options are available
       window.placesDataset = placesAutocompleteDataset({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         algoliasearch,
         templates: {
           header: '<div class="ad-example-header">Cities</div>'

--- a/test/cdn-autocomplete/index.html
+++ b/test/cdn-autocomplete/index.html
@@ -74,6 +74,8 @@
       // we automatically inject the default CSS
       // all the places.js options are available
       window.placesDataset = placesAutocompleteDataset({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         algoliasearch,
         templates: {
           header: '<div class="ad-example-header">Cities</div>'

--- a/test/cdn-main-min/index.html
+++ b/test/cdn-main-min/index.html
@@ -8,6 +8,8 @@
     <script type="text/javascript" src="../../dist/cdn/places.min.js"></script>
     <script>
       window.placesAutocomplete = places({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         container: document.querySelector('#search-box'),
         debug: true,
       });

--- a/test/cdn-main/index.html
+++ b/test/cdn-main/index.html
@@ -8,6 +8,8 @@
     <script type="text/javascript" src="../../dist/cdn/places.js"></script>
     <script>
       window.placesAutocomplete = places({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         container: document.querySelector('#search-box'),
         debug: true,
       });

--- a/test/cdn-widget-min/index.html
+++ b/test/cdn-widget-min/index.html
@@ -20,6 +20,8 @@
       });
       
       const searchBox = placesInstantsearchWidget({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         container: document.querySelector('#search-box')
       });
       

--- a/test/cdn-widget/index.html
+++ b/test/cdn-widget/index.html
@@ -20,6 +20,8 @@
       });
       
       const searchBox = placesInstantsearchWidget({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         container: document.querySelector('#search-box')
       });
       

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -88,6 +88,10 @@ describe('releases', () => {
       page = await browser.newPage();
       await page.goto(url);
 
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
+
       page.on('error', err => {
         throw new Error(err);
       });
@@ -235,6 +239,10 @@ describe('releases', () => {
       });
       page = await browser.newPage();
       await page.goto(url);
+
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
 
       page.on('error', err => {
         throw new Error(err);
@@ -384,6 +392,10 @@ describe('releases', () => {
       page = await browser.newPage();
       await page.goto(url);
 
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
+
       page.on('error', err => {
         throw new Error(err);
       });
@@ -532,6 +544,10 @@ describe('releases', () => {
       page = await browser.newPage();
       await page.goto(url);
 
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
+
       page.on('error', err => {
         throw new Error(err);
       });
@@ -613,6 +629,10 @@ describe('releases', () => {
       page = await browser.newPage();
       await page.goto(url);
 
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
+
       page.on('error', err => {
         throw new Error(err);
       });
@@ -689,6 +709,10 @@ describe('releases', () => {
       });
       page = await browser.newPage();
       await page.goto(url);
+
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
 
       page.on('error', err => {
         throw new Error(err);
@@ -782,6 +806,10 @@ describe('releases', () => {
       });
       page = await browser.newPage();
       await page.goto(url);
+
+      await page.setExtraHTTPHeaders({
+        referer: 'https://community.algolia.com/',
+      });
 
       page.on('error', err => {
         throw new Error(err);

--- a/test/npm-lib/index.html
+++ b/test/npm-lib/index.html
@@ -8,6 +8,8 @@
     <script type="text/javascript" src="./places.js"></script>
     <script>
       window.placesAutocomplete = places({
+        appId: 'plFMJJT5O9PC',
+        apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         container: document.querySelector('#search-box'),
         debug: true,
       });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
This PR makes it so that our e2e tests use an authenticated places app instead of the unauthenticated mode. The api key we use is restricted to community.algolia.com.

This fixes issues where certain tests would fail because the queries were rejected due to having reached the limits.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
```
yarn test
```
works no matter how many times they are run.
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
