### PR TITLE
doc(fix-php-example): use latest syntax for instantiating places client

### DIFF
--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -48,7 +48,7 @@ You can directly query the [Places REST API](api-clients.html#rest-api) with our
 $appId = 'YOUR_PLACES_APP_ID';
 $apiKey = 'YOUR_PLACES_API_KEY';
 
-$places = \AlgoliaSearch\Client::initPlaces($appId, $apiKey);
+$places = \Algolia\AlgoliaSearch\PlacesClient::create($appId, $apiKey);
 
 $result = $places->search('Paris');
 var_dump($result);

--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -54,6 +54,8 @@ $result = $places->search('Paris');
 var_dump($result);
 ```
 
+**Important:** the following syntax is correct for version 2.0.0 and above of the PHP API client. The API client documentation has a guide on [how to migrate from version 1 to version 2](https://www.algolia.com/doc/api-client/getting-started/upgrade-guides/php/#places-index-instantiation)
+
 Note: _Like with the Places.js library, you need to provide your Places App credentials in order for the clients to function properly. If you do not have a Places application, you can create one by [signing up for free](https://www.algolia.com/users/sign_up/places)._
 
 ### Swift API Client


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Our code sample for the PHP client was outdated since there was a major release of the PHP client which changed the way to instantiate a places client.

This PR corrects that code and provides a link to the migration guide for people using the php client v1.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

