### PR TITLE
feat(accessibility): allow modification of attributes on pin and clear buttons

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -208,6 +208,31 @@ Control whether the default styles should be used.
 **Important**: This parameter can only be set at instantiation.
 </td>
     </tr>
+    <tr>
+<td markdown="1">
+<div class="api-entry" id="api-options-appId"><code>accessibility</code></div>
+
+Type: **Object**
+</td>
+<td markdown="1">
+an object containing a `pinButton` and/or `clearButton` object which is composed of html attributes to apply to the corresponding button
+
+**Example**:
+```
+accessibility: {
+  pinButton: {
+    'aria-label': 'use browser geolocation',
+    'tab-index': 12,
+  },
+  clearButton: {
+    'tab-index': 13,
+  }
+}
+```
+
+**Important**: This parameter can only be set at instantiation.
+</td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/places.js
+++ b/src/places.js
@@ -17,10 +17,19 @@ insertCss(css, { prepend: true });
 import errors from './errors';
 import createReverseGeocodingSource from './createReverseGeocodingSource';
 
+const applyAttributes = (elt, attrs) => {
+  Object.entries(attrs).forEach(([name, value]) => {
+    elt.setAttribute(name, `${value}`);
+  });
+
+  return elt;
+};
+
 export default function places(options) {
   const {
     container,
     style,
+    accessibility,
     autocompleteOptions: userAutocompleteOptions = {},
   } = options;
 
@@ -119,6 +128,13 @@ export default function places(options) {
   const clear = document.createElement('button');
   clear.setAttribute('type', 'button');
   clear.setAttribute('aria-label', 'clear');
+  if (
+    accessibility &&
+    accessibility.clearButton &&
+    accessibility.clearButton instanceof Object
+  ) {
+    applyAttributes(clear, accessibility.clearButton);
+  }
   clear.classList.add(`${prefix}-input-icon`);
   clear.classList.add(`${prefix}-icon-clear`);
   clear.innerHTML = clearIcon;
@@ -128,6 +144,13 @@ export default function places(options) {
   const pin = document.createElement('button');
   pin.setAttribute('type', 'button');
   pin.setAttribute('aria-label', 'focus');
+  if (
+    accessibility &&
+    accessibility.pinButton &&
+    accessibility.pinButton instanceof Object
+  ) {
+    applyAttributes(pin, accessibility.pinButton);
+  }
   pin.classList.add(`${prefix}-input-icon`);
   pin.classList.add(`${prefix}-icon-pin`);
   pin.innerHTML = pinIcon;

--- a/test/npm-lib/index.html
+++ b/test/npm-lib/index.html
@@ -11,6 +11,19 @@
         appId: 'plFMJJT5O9PC',
         apiKey: 'a0f8e2d480b9d119f485836d77db4e53',
         container: document.querySelector('#search-box'),
+        autocompleteOptions: {
+          ariaLabel: 'address search'
+        },
+        accessibility: {
+          pinButton: {
+            'aria-label': 'use browser geolocation',
+            'tab-index': 2
+          },
+          clearButton: {
+            'arial-label': 'clear search',
+            'tab-index': 2
+          }
+        },
         debug: true,
       });
     </script>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

closes #860

**Summary**
This PR enables our users to apply arbitrary attributes on the clear and pin buttons, which enables one to override aria-labels if desired, set a tab-index, etc.

This PR also updates the documentation to present that functionality
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**
attributes set in accessibility are propagated to the correct button (as shown in `test/npm-lib/index.html`)
<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
