### PR TITLE
chore(deps): remove eslint-plugin-jasmine from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "eslint-config-prettier": "6.5.0",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-jasmine": "2.10.1",
     "eslint-plugin-jest": "22.21.0",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,11 +3038,6 @@ eslint-plugin-import@2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
-eslint-plugin-jasmine@2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.10.1.tgz#5733b709e751f4bc40e31e1c16989bd2cdfbec97"
-  integrity sha1-VzO3CedR9LxA4x4cFpib0s377Jc=
-
 eslint-plugin-jest@22.21.0:
   version "22.21.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.21.0.tgz#8137294645866636160487d9764224b9a43e2eb1"


### PR DESCRIPTION
**Summary**
`eslint-plugin-jasmine` is a plugin to use to lint files using the jasmine testing library. We have been using jest for a while now (which uses jasmine underneath), and the linting rules relevant for jasmine are already covered by the `eslint-plugin-jest` in our dev deps.
