### PR TITLE
chore(deps): bump algoliasearch to 3.35.1 and move algolia-aerial to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/plugin-syntax-import-meta": "7.7.4",
     "@babel/polyfill": "7.7.0",
     "@babel/preset-env": "7.7.4",
+    "algolia-aerial": "^1.5.3",
     "algoliasearch-helper": "2.28.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.3",
@@ -77,8 +78,7 @@
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "algolia-aerial": "^1.5.3",
-    "algoliasearch": "^3.31.0",
+    "algoliasearch": "^3.35.1",
     "autocomplete.js": "^0.37.0",
     "events": "^3.0.0",
     "insert-css": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,7 +1438,7 @@ algoliasearch-helper@2.28.0:
     lodash "^4.17.5"
     qs "^6.5.1"
 
-algoliasearch@^3.24.5, algoliasearch@^3.31.0:
+algoliasearch@^3.24.5, algoliasearch@^3.35.1:
   version "3.35.1"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
   integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==


### PR DESCRIPTION
Closes #939

**Summary**
This PR updates the version of algoliasearch and moves algolia-aerial to a dev-deps as it is only used in the docs build, rather than in the library.