### PR TITLE
chore(better-ci): remove yarn installation from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js: stable
 before_install:
 - git config --global user.email "algobot@users.noreply.github.com"
 - git config --global user.name "algobot"
-- rvm install $(cat .ruby-version)
-- rvm use
+- rvm install 2.4.0
+- rvm use 2.4.0
 - "(cd docs && bundle install)"
 script:
 - npm run test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: stable
 before_install:
 - git config --global user.email "algobot@users.noreply.github.com"
 - git config --global user.name "algobot"
-- rvm install
+- rvm install $(cat .ruby-version)
 - rvm use
 - "(cd docs && bundle install)"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js: stable
 before_install:
-- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
 - git config --global user.email "algobot@users.noreply.github.com"
 - git config --global user.name "algobot"
-- rvm install 2.4.0
-- rvm use 2.4.0
+- rvm install
+- rvm use
 - "(cd docs && bundle install)"
 script:
 - npm run test:ci


### PR DESCRIPTION
**Summary**
This PR removes the pre_install step of installing yarn (since it's now supported by travis by default).

**Result**
CI should be green and with up-to-date yarn versions.