### PR TITLE
feat(postcode-search): add postcodeSearch attribute

### DIFF
--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -223,6 +223,21 @@ Available types:
     </tr>
     <tr>
 <td markdown="1">
+<div class="api-entry" id="api-options-postcode-search"><code>restrictSearchableAttributes</code></div>
+Type: string
+</td>
+<td markdown="1">
+Restrict the fields in which the search is done.
+
+Available fields:
+
+- `postcode`
+
+**Note**: This parameter is only useful to search for postcodes.
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
 <div class="api-entry" id="api-options-type"><code>hitsPerPage</code></div>
 Type: number
 </td>

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -281,6 +281,18 @@ Available types:
     </tr>
     <tr>
 <td markdown="1">
+<div class="api-entry" id="api-options-postcode-search"><code>postcodeSearch</code></div>
+
+Type: **boolean**
+</td>
+<td markdown="1">
+Only search in the postcode field.
+
+**Default**: false.
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
 <div class="api-entry" id="api-options-language"><code>language</code></div>
 
 Type: **string**

--- a/docs/source/examples.html.md.erb
+++ b/docs/source/examples.html.md.erb
@@ -258,6 +258,18 @@ In this section, we will see how you can do reverse geocoding with a precision u
 
 **Note:** There are many use cases where you will want to combine the reverse geocoding API with the regular Places search. In this case, you do not need to import both the standard Places library and the JS Client, as the reverse functionality is included in the standard Places.js library. You can access the reverse endpoint programmatically using `placesInstance.reverse(location)`.
 
+### Postcode search
+
+Using the `postcodeSearch` attribute, you can restrict the search to the postcodes field only.
+
+**Important:** While this attribute will improve the quality of the search when looking for postcode, please note that postcode in OSM are sparse and that some postcodes may be missing or approximate. As such, we recommend you to always let the user modify this section and only rely on this data as a mean to suggest rather than a source of truth.
+
+<%= partial '/partials/examples/postcode_search', locals: config[:credentials][:documentation] %>
+
+```html
+<%= partial '/partials/examples/postcode_search', locals: config[:credentials][:placeholder] %>
+```
+
 ### Dynamic Form
 
 **Concepts:** dynamic configuration, reverse API, multiple instance.

--- a/docs/source/partials/examples/_postcode_search.html.erb
+++ b/docs/source/partials/examples/_postcode_search.html.erb
@@ -1,0 +1,16 @@
+<input type="search" id="docs-postcode-search" class="form-control" placeholder="Search for a french city by postcode (e.g. 75008)" />
+
+<%= javascript_include_tag config[:places_lib_url] %>
+<script>
+(function() {
+  var placesAutocomplete = places({
+    appId: '<%= app_id %>',
+    apiKey: '<%= api_key %>',
+    container: document.querySelector('#docs-postcode-search')
+  }).configure({
+    postcodeSearch: true,
+    countries: ['fr'],
+    type: 'city'
+  });
+})();
+</script>

--- a/src/configure/index.js
+++ b/src/configure/index.js
@@ -1,5 +1,6 @@
 const extractParams = ({
   hitsPerPage,
+  postcodeSearch,
   aroundLatLng,
   aroundRadius,
   aroundLatLngViaIP,
@@ -31,6 +32,10 @@ const extractParams = ({
     extracted.aroundLatLng = aroundLatLng;
   } else if (aroundLatLngViaIP !== undefined) {
     extracted.aroundLatLngViaIP = aroundLatLngViaIP;
+  }
+
+  if (postcodeSearch) {
+    extracted.restrictSearchableAttributes = 'postcode';
   }
 
   return {


### PR DESCRIPTION
**Summary**
Adds a `postcodeSearch` attribute to places.js and documents it (in documentation and in examples).

Adds documentation for the underlying usage of the REST API `restrictSearchableAttributes` parameter.
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
