### PR TITLE
docs: mention max hitsPerPage

### DIFF
--- a/docs/source/api-clients.html.md.erb
+++ b/docs/source/api-clients.html.md.erb
@@ -242,7 +242,7 @@ Available fields:
 Type: number
 </td>
 <td markdown="1">
-Specifies how many results you want to retrieve per search.
+Specifies how many results you want to retrieve per search, with a maximum of 20.
 
 **Default**: 20.
 </td>


### PR DESCRIPTION
**Summary**
The `hitsPerPage` parameter is limited to 20 max, but I couldn't find this mentioned anywhere in the documentation.
