### PR TITLE
chore(is-docs): document change of ownership of places IS widget

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -877,6 +877,10 @@ If you're already using instantsearch.js, you can use Algolia Places out of the 
 widget will do a search of places using Algolia Places and when an address is selected, it
 will update the geolocation point of the instantsearch.js search.
 
+**Important:** With the release of InstantSearch.JS v4, the places widget has been re-worked and is now living in the InstantSearch repository. You can find an example of how to setup the widget in the [geo-search story](https://github.com/algolia/instantsearch.js/blob/master/stories/geo-search.stories.js) of the [InstantSearch repository](https://github.com/algolia/instantsearch.js)
+
+If you are using InstantSearch v3, you can rely on the example below.
+
 You can include it using a link tag:
 
 ```html


### PR DESCRIPTION
closes #1004 

**Summary**
This PR documents the fact that the IS widget is now owned by the InstantSearch repository.

**Result**
![image](https://user-images.githubusercontent.com/5136989/82816478-82cfd700-9e9b-11ea-9d2f-1614d62c52bc.png)
