### PR TITLE
feat(autocomplete): add locate event when pin is clicked

### DIFF
--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -546,6 +546,19 @@ live on the [map example](examples.html#link-to-a-map).
     </tr>
     <tr>
 <td markdown="1">
+<div class="api-entry" id="api-events-locate"><code>locate</code></div>
+
+Event data: `undefined`
+
+</td>
+<td markdown="1">
+Fired when the location pin is clicked. This event doesn't return anything.
+
+You can use this event when the user has chosen to enable geolcation in the browser by clicking on the pin icon.
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
 <div class="api-entry" id="api-events-limit"><code>limit</code></div>
 
 Event data:

--- a/src/places.js
+++ b/src/places.js
@@ -159,6 +159,7 @@ export default function places(options) {
   pin.addEventListener('click', () => {
     autocompleteDataset.source.configure({ useDeviceLocation: true });
     autocompleteInstance.focus();
+    placesInstance.emit('locate');
   });
 
   clear.addEventListener('click', () => {

--- a/src/places.test.js
+++ b/src/places.test.js
@@ -160,9 +160,19 @@ describe('places', () => {
 
   describe('places autocomplete', () => {
     let placesInstance;
+    let configureMock;
 
     beforeEach(() => {
       autocomplete.mockClear();
+      createAutocompleteDataset.mockClear();
+      configureMock = jest.fn();
+      createAutocompleteDataset.mockImplementation(() => ({
+        source: {
+          configure: configureMock,
+        },
+        other: 'autocompleteDataset',
+      }));
+
       const container = document
         .querySelector('body')
         .appendChild(document.createElement('input'));
@@ -184,7 +194,7 @@ describe('places', () => {
         },
         {
           source: {
-            configure: 'configure',
+            configure: configureMock,
           },
           other: 'autocompleteDataset',
         }
@@ -307,6 +317,22 @@ describe('places', () => {
       );
       expect(pinButton.style.display).toEqual('');
       expect(pinButton.getAttribute('aria-label')).toEqual('focus');
+    });
+
+    it('triggers a locate event on pin click', () => {
+      return new Promise((done) => {
+        const pinButton = document.querySelector('.ap-icon-pin');
+        placesInstance.once('locate', () => {
+          expect(configureMock).toHaveBeenCalledWith({
+            useDeviceLocation: true,
+          });
+
+          expect(autocomplete.__instance.focus).toHaveBeenCalled();
+          done();
+        });
+
+        pinButton.dispatchEvent(new Event('click'));
+      });
     });
 
     describe('input listener', () => {


### PR DESCRIPTION
**Summary**
Allow the pin to emit a `locate` event when clicked. This will allow integrating code to determine when a user enables geolocation in the browser and act upon it.

This addresses an issue as discussed in algolia/places#952.

I came across this too as I wanted to use the `places` module in a Facebook Messenger Webview. The pin icon looks like it should geolocate the user so having this as an additional event would allow me to do this without tying it to the `places` implementation.

I chose the name `locate` for the event but I'm happy to change this to a better name if appropriate. I've added a unit test for this but had to refactor the mocking of `createAutocompleteDataset` as it's set up prior to the `places` instance being created before every test. I felt this was appropriate but happy to refactor this.

The documentation has been updated.

**Result**

The `locate` event is emitted when clicking on the pin icon to allow users to determine when this has happend.