### PR TITLE
fix(deps): revert auto-upgrade of pending-xhr-puppetteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,9 @@
     "eslint-plugin-react": "7.21.3",
     "jest-cli": "26.4.2",
     "json": "9.0.6",
-    "pending-xhr-puppeteer": "2.3.2",
     "prettier": "2.1.2",
     "pretty-bytes-cli": "2.0.0",
-    "puppeteer": "5.3.1",
+    "puppeteer": "5.3.0",
     "raw-loader": "4.0.1",
     "replace-in-file": "6.1.0",
     "semver": "7.3.2",
@@ -81,7 +80,8 @@
     "algoliasearch": "^3.35.1",
     "autocomplete.js": "^0.38.0",
     "events": "^3.0.0",
-    "insert-css": "^2.0.0"
+    "insert-css": "^2.0.0",
+    "pending-xhr-puppeteer": "1.0.17"
   },
   "jest": {
     "testRegex": "\\.test\\.js$",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6139,6 +6139,11 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.43.0"
 
+mime@^2.0.3:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
+  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -6809,10 +6814,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-pending-xhr-puppeteer@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/pending-xhr-puppeteer/-/pending-xhr-puppeteer-2.3.2.tgz#c86746e8534a36d4e2030bd53446ae9ab6eb14d9"
-  integrity sha512-ETd4nUVjSr7pKzQGjGu80lkXF70tjAJDMLK1EZTGPixs0jj0Yx78nSDNEUSk1Y/Zo3humdMR2pVebN07AP2x2A==
+pending-xhr-puppeteer@1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/pending-xhr-puppeteer/-/pending-xhr-puppeteer-1.0.17.tgz#7b9b17c6cd56acce3eb229a25732e130072a4eeb"
+  integrity sha512-Z5yI27414aZrkyEjjpRoSYh/5HnKWaCTcAPTq+I3D29ZdMCSJhqz3rFPWM2bX1nMScbJcsuvWbDq8lmQGPCAGA==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -7051,15 +7056,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.3.1.tgz#324e190d89f25ac33dba539f57b82a18553f8646"
-  integrity sha512-YTM1RaBeYrj6n7IlRXRYLqJHF+GM7tasbvrNFx6w1S16G76NrPq7oYFKLDO+BQsXNtS8kW2GxWCXjIMPvfDyaQ==
+puppeteer@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.3.0.tgz#0abf83d0f2d1273baf2b56885a813f8052903e33"
+  integrity sha512-GjqMk5GRro3TO0sw3QMsF1H7n+/jaK2OW45qMvqjYUyJ7y4oA//9auy969HHhTG3HZXaMxY/NWXF/NXlAFIvtw==
   dependencies:
     debug "^4.1.0"
     devtools-protocol "0.0.799653"
     extract-zip "^2.0.0"
     https-proxy-agent "^4.0.0"
+    mime "^2.0.3"
     pkg-dir "^4.2.0"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
This PR reverts an auto-upgrade of a dependency that made tests flaky.

**Result**
```
yarn test:e2e
# works!
```