### PR TITLE
doc(contact-form): add html redirect to page

### DIFF
--- a/docs/source/layouts/landing.erb
+++ b/docs/source/layouts/landing.erb
@@ -30,6 +30,9 @@
     <% if current_page.path == 'index.html' %>
     <link rel=canonical href="https://community.algolia.com/places">
     <% end %>
+    <% if current_page.path == 'contact.html' %>
+    <meta http-equiv="refresh" content="0; URL='https://www.algolia.com/contactus/'" />
+    <% end %>
 
     <%= stylesheet_link_tag(:landing) %>
     <%= auto_stylesheet_link_tag %>

--- a/docs/source/layouts/layout.erb
+++ b/docs/source/layouts/layout.erb
@@ -30,6 +30,9 @@
     <% if current_page.path == 'index.html' %>
     <link rel=canonical href="https://community.algolia.com/places">
     <% end %>
+    <% if current_page.path == 'contact.html' %>
+    <meta http-equiv="refresh" content="0; URL='https://www.algolia.com/contactus/'" />
+    <% end %>
 
     <%= stylesheet_link_tag :site %>
     <%= auto_stylesheet_link_tag %>


### PR DESCRIPTION
**Summary**
This PR adds an html redirect to the `contact.html` page, so that it automatically redirects to `https://www.algolia.com/contactus/` even if clicked from google.

**Result**
N/A
