### PR TITLE
chore(docs): update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version][version-svg]][package-url] [![Build Status][travis-svg]][travis-url] [![License][license-image]][license-url] [![Downloads][downloads-image]][downloads-url] [![jsDelivr Hits][jsdelivr-badge]][jsdelivr-url]
 
 ## Deprecation of service
-> Places is going away on May 31st 2022. [Read our blog post announcement.](https://www.algolia.com/blog/sunsetting-our-places-feature/)
+> Places is going away on May 31st 2022. [Read our blog post announcement.](https://www.algolia.com/blog/product/sunsetting-our-places-feature/)
 
 ## Introduction
 

--- a/docs/source/documentation.html.md.erb
+++ b/docs/source/documentation.html.md.erb
@@ -3,7 +3,7 @@ title: Documentation
 layout: documentation
 ---
 ## Places Sunset
-Algolia Places is being sunset on May 31st, 2022. We invite you to read [our announcement](https://www.algolia.com/blog/sunsetting-our-places-feature/) and consider alternatives.
+Algolia Places is being sunset on May 31st, 2022. We invite you to read [our announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) and consider alternatives.
 
 **Important**: Sign-ups have been disabled.
 

--- a/docs/source/partials/navigation.html.haml
+++ b/docs/source/partials/navigation.html.haml
@@ -1,7 +1,7 @@
 .ac-nav
   .ac-nav-container
     .ac-announcement
-      %a{href: "https://www.algolia.com/blog/sunsetting-our-places-feature/", title: "Places is going away on May 31st 2022. Read our announcement."} Places is going away on May 31st 2022. Read our announcement.
+      %a{href: "https://www.algolia.com/blog/product/sunsetting-our-places-feature/", title: "Places is going away on May 31st 2022. Read our announcement."} Places is going away on May 31st 2022. Read our announcement.
   .ac-nav-container
     .ac-nav-brand
       %a.ac-logo{:href => "https://community.algolia.com/", :title => "Algolia Community"}


### PR DESCRIPTION
**Summary**
This PR fixes an orphan link due to the blog maintainers moving the sunset announcement to a new location without redirects.
