### PR TITLE
chore(env): add module compatibility

### DIFF
--- a/docs/source/javascripts/index.js
+++ b/docs/source/javascripts/index.js
@@ -9,7 +9,7 @@ const placesAutocomplete = places({
 });
 $input.style.opacity = 1; // we initially hide the input to avoid size flickering
 
-if (process.env.NODE_ENV === 'development') {
+if ((import.meta.env.NODE_ENV || process.env.NODE_ENV) === 'development') {
   const events = ['change', 'suggestions', 'cursorchanged'];
   events.forEach((eventName) =>
     placesAutocomplete.on(eventName, (eventData) => {

--- a/scripts/bump-package-version.js
+++ b/scripts/bump-package-version.js
@@ -6,12 +6,12 @@ import replace from 'replace-in-file';
 import semver from 'semver';
 import currentVersion from '../src/version';
 
-if (!process.env.VERSION) {
+if (!(import.meta.env.VERSION || process.env.VERSION)) {
   throw new Error(
     'bump: Usage is VERSION=MAJOR.MINOR.PATCH scripts/bump-package-version.js'
   );
 }
-const newVersion = process.env.VERSION;
+const newVersion = (import.meta.env.VERSION || process.env.VERSION);
 
 if (!semver.valid(newVersion)) {
   throw new Error(

--- a/src/places.js
+++ b/src/places.js
@@ -64,7 +64,7 @@ export default function places(options) {
       root: `algolia-places${style === false ? '-nostyle' : ''}`,
       prefix,
     },
-    debug: process.env.NODE_ENV === 'development',
+    debug: (import.meta.env.NODE_ENV || process.env.NODE_ENV) === 'development',
     ...userAutocompleteOptions,
   };
 

--- a/webpack.config.docs.js
+++ b/webpack.config.docs.js
@@ -4,10 +4,10 @@ const { join } = require('path');
 
 module.exports = {
   ...baseConfig,
-  entry: `./docs/source/javascripts/${process.env.BUNDLE}.js`,
+  entry: `./docs/source/javascripts/${(import.meta.env.BUNDLE || process.env.BUNDLE)}.js`,
   output: {
     path: join(__dirname, 'docs/.webpack/js'),
-    filename: `${process.env.BUNDLE}.js`,
+    filename: `${(import.meta.env.BUNDLE || process.env.BUNDLE)}.js`,
   },
 };
 /* eslint-enable import/no-commonjs */


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This pull request fixes an issue with modules packages (e.g a Vite project) by including the new convention of javascript modules (``import.meta.env`` instead of using ``process.env``).

**Result**

Fixes this error:

![image](https://user-images.githubusercontent.com/25107942/156933727-0bc1e9a7-bf66-462c-874a-f279c842fe9d.png)

